### PR TITLE
Adopt flat pages registry and hierarchical packs in root manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+﻿name: CI
+
+on:
+  pull_request:
+    branches: ['**']
+  push:
+    branches: ['main', 'fixtures/**']
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          format: parsable
+          config_file: .yamllint.yml
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: |
+            **/*.md
+            !node_modules/**
+
+  validate-schema-and-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml jsonschema
+      - name: Validate root manifest
+        run: python tools/validate_repo.py validate-root manifest.yml schema/root-manifest.schema.json
+      - name: Validate all pack.yml + pages
+        run: python tools/validate_repo.py validate-packs packs schema/pack.schema.json

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+﻿{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,10 @@
+﻿extends: default
+rules:
+  line-length: disable
+  truthy: disable
+  document-start: disable
+  indentation:
+    indent-sequences: consistent
+  empty-lines:
+    max: 2
+  trailing-spaces: enable

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Upstream repository: `Aharoni-Lab/labki-packs` on GitHub.
 
 ## Repository structure
 
-```
+```text
 labki-packs/
 ├─ manifest.yml          # Root registry: pages (flat) + packs (hierarchy of includes)
 ├─ README.md

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,14 +1,14 @@
 ﻿# Conventions
 
-## Layout
-- Every directory under `packs/` is a pack and includes a `pack.yml`.
-- Packs may contain a `pages/` folder with one file per page.
+## Layout (v2)
+- All page files live under the top-level `pages/` directory.
+- Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`.
+- Packs are defined only in the root `manifest.yml` under `packs` and reference titles from the global `pages` registry.
 - Use `.wiki` for wikitext content and `.md` for Markdown content.
 
 ## Filenames and titles
-- Avoid `:` in filenames for cross-platform compatibility (Windows).
-- Prefer explicit mapping in `pack.yml` using `pages:` entries with `title` or `namespace`+`name`.
-- Optionally include a first-line comment `<!-- Title: Namespace:Name -->` inside the file as a secondary hint.
+- Avoid `:` in filenames (Windows-safe); use prefixes like `Template_`, `Form_`, etc.
+- Canonical titles are defined in `manifest.yml` under `pages` keys; importers use this as the source of truth.
 - One page per file.
 
 ## Templates, forms, properties, categories
@@ -17,8 +17,9 @@
 - Categories should include a concise description of scope and usage.
 
 ## Versioning
-- Use semantic versioning (MAJOR.MINOR.PATCH) in each `pack.yml`.
-- Keep the root `manifest.yml` up-to-date and maintain `last_updated`.
+- Track per-page version in `manifest.yml` under `pages.*.version`.
+- Use semantic versioning (MAJOR.MINOR.PATCH).
+- Update `last_updated` when significant changes are merged.
 
 ## Style
 - Keep wikitext minimal and portable.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,26 +1,31 @@
 ﻿# Conventions
 
 ## Layout (v2)
+
 - All page files live under the top-level `pages/` directory.
 - Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`.
 - Packs are defined only in the root `manifest.yml` under `packs` and reference titles from the global `pages` registry.
 - Use `.wiki` for wikitext content and `.md` for Markdown content.
 
 ## Filenames and titles
+
 - Avoid `:` in filenames (Windows-safe); use prefixes like `Template_`, `Form_`, etc.
 - Canonical titles are defined in `manifest.yml` under `pages` keys; importers use this as the source of truth.
 - One page per file.
 
 ## Templates, forms, properties, categories
+
 - Templates (`Template:Name`) and forms (`Form:Name`) should be paired where applicable.
 - Semantic properties should declare types (e.g., `[[Has type::Text]]`).
 - Categories should include a concise description of scope and usage.
 
 ## Versioning
+
 - Track per-page version in `manifest.yml` under `pages.*.version`.
 - Use semantic versioning (MAJOR.MINOR.PATCH).
 - Update `last_updated` when significant changes are merged.
 
 ## Style
+
 - Keep wikitext minimal and portable.
 - Avoid environment-specific hardcoding or external dependencies.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,12 +1,14 @@
 ﻿# Development
 
 ## Adding pages and packs (v2)
+
 1. Add or edit files under the top-level `pages/` directory (group by type if desired).
 2. In `manifest.yml`, add entries under `pages:` with canonical titles, file paths, `type`, and `version`.
 3. Under `packs:`, reference the titles you want included in each pack and arrange nested packs under `children`.
 4. Commit and open a PR.
 
 ## Extension development quickstart
+
 1. Scaffold `extensions/LabkiPackManager/` with `extension.json`, `includes/`, `i18n/`.
 2. Register and verify on `Special:Version`.
 3. Implement `Special:LabkiPackManager` page to render list and refresh.
@@ -17,6 +19,7 @@
 8. Document configuration and Docker integration.
 
 ## Testing
+
 - Unit tests for YAML parsing, manifest traversal, and import logic.
 - Integration tests against a local MediaWiki instance when feasible.
 
@@ -27,9 +30,11 @@
 - Include heuristic-only cases derived from filenames.
 
 ## CI
+
 - Run PHPCS and PHPUnit on PRs.
 - Optional: validate manifests with `schema/`.
 
 ## Docker integration
+
 - Clone or mount the extension under `extensions/LabkiPackManager`.
 - Add `wfLoadExtension( 'LabkiPackManager' );` to `LocalSettings.php`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,18 +1,17 @@
 ﻿# Development
 
-## Adding a new pack to this repository
-1. Create a new directory under `packs/your-pack/` (nested packs are allowed).
-2. Add `pack.yml` with `name`, `version`, `description`, `pages`, `dependencies`.
-3. Add pages under `packs/your-pack/pages/` as `.wiki` or `.md`.
-4. Update the root `manifest.yml` to include a `ref` to the new `pack.yml` and nest it appropriately in `children`.
-5. Commit and open a PR.
+## Adding pages and packs (v2)
+1. Add or edit files under the top-level `pages/` directory (group by type if desired).
+2. In `manifest.yml`, add entries under `pages:` with canonical titles, file paths, `type`, and `version`.
+3. Under `packs:`, reference the titles you want included in each pack and arrange nested packs under `children`.
+4. Commit and open a PR.
 
 ## Extension development quickstart
 1. Scaffold `extensions/LabkiPackManager/` with `extension.json`, `includes/`, `i18n/`.
 2. Register and verify on `Special:Version`.
 3. Implement `Special:LabkiPackManager` page to render list and refresh.
 4. Implement manifest fetch/caching (HTTP + YAML parse).
-5. Implement import: resolve `pack.yml` and fetch `pages/` files; save via `PageUpdater`.
+5. Implement import (v2): resolve pack titles via root `manifest.yml` `pages` registry; fetch `file` and save via `PageUpdater`.
 6. Add `labkipackmanager-manage` right and restrict access.
 7. Add PHPUnit tests and GitHub Actions CI.
 8. Document configuration and Docker integration.

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,7 @@
 - Integration tests against a local MediaWiki instance when feasible.
 
 ### Test title mapping
+
 - Include cases where `pages:` entries specify `title`.
 - Include cases with `namespace`+`name`.
 - Include files with a leading `<!-- Title: Namespace:Name -->` comment.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -3,6 +3,7 @@
 ## Root manifest (manifest.yml)
 
 Fields:
+
 - `version` (string): manifest schema/version of the registry (v2 and up)
 - `last_updated` (date/string): informational timestamp
 - `pages` (mapping): global flat registry of pages

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,89 +1,52 @@
-﻿# Manifest specification
+﻿# Manifest specification (v2)
 
 ## Root manifest (manifest.yml)
 
 Fields:
-- `version` (string): manifest schema/version of the registry
+- `version` (string): manifest schema/version of the registry (v2 and up)
 - `last_updated` (date/string): informational timestamp
+- `pages` (mapping): global flat registry of pages
+  - key: canonical wiki title (e.g., `Template:Microscope`)
+  - value: object with fields:
+    - `file` (string): repository path to the file under `pages/`
+    - `type` (string): one of `template|form|category|property|layout|other`
+    - `version` (string): semantic version for this page
+    - `description` (string, optional)
 - `packs` (mapping): hierarchical tree of packs
   - Each key is a node id; value has:
-    - `ref` (string): relative path to the node's `pack.yml`
+    - `description` (string, optional)
+    - `pages` (array of strings): list of page titles from the global `pages` registry
     - `children` (mapping, optional): nested packs with same structure
 
 Example:
 
 ```yaml
-version: 1.0.0
+version: 2.0.0
 last_updated: 2025-09-22
+
+pages:
+  Template:Microscope:
+    file: pages/Templates/Template_Microscope.wiki
+    type: template
+    version: 1.0.0
+
 packs:
   lab-operations:
-    ref: packs/lab-operations/pack.yml
+    description: Lab operations content
+    pages:
+      - Template:Microscope
     children:
       equipment:
-        ref: packs/lab-operations/equipment/pack.yml
+        description: Equipment-related packs
+        pages: []
 ```
 
-## Pack manifest (pack.yml)
+## Title resolution and filenames
 
-Fields:
-- `name` (string): human-friendly name (typically equals directory name)
-- `version` (string): semantic version (MAJOR.MINOR.PATCH)
-- `description` (string): brief description
-- `pages` (array): list of page entries. Each entry can be either:
-  - string: path to `.wiki`/`.md` file (e.g., `pages/foo.wiki`)
-  - object: `{ file, title? , namespace?, name? }` to explicitly set the wiki page title
-- `dependencies` (array of strings): extension requirements or other packs (informational)
+- Canonical titles are the keys of the `pages` mapping; files are Windows-safe and live under `pages/`.
+- Filenames must not include `:`. Use underscores around the namespace prefix in filenames, e.g., `Template_Microscope.wiki`.
+- Importers do not guess titles from filenames in v2; they look up titles via the `pages` registry.
 
-Example parent pack:
+## Backward compatibility (v1)
 
-```yaml
-name: lab-operations
-version: 2.1.0
-description: "Guides and procedures for day-to-day lab operations."
-pages:
-  - pages/safety_overview.wiki
-  - pages/general_policies.wiki
-dependencies: []
-```
-
-Example intermediate/leaf pack:
-
-```yaml
-name: imaging
-version: 2.0.0
-description: "Imaging-related tools and methods."
-pages: []
-dependencies: []
-```
-
-### Page entries and title resolution
-
-Because filenames may be Windows-safe (no `:`), use explicit mapping where necessary.
-
-Allowed page entry formats:
-
-```yaml
-pages:
-  # Explicit title mapping (preferred for namespaced pages)
-  - file: pages/Template_Onboarding.wiki
-    title: "Template:Onboarding"
-
-  # Alternative explicit mapping via namespace + name
-  - file: pages/Form_Onboarding.wiki
-    namespace: Form
-    name: Onboarding
-
-  # Simple string file path (heuristic fallback)
-  - pages/meeting_layout.md
-```
-
-Resolver order:
-1. Use `title` if present.
-2. Else combine `namespace` + `name`.
-3. Else read leading comment `<!-- Title: Namespace:Name -->` in file.
-4. Else derive from filename using project heuristics.
-
-## Resolution rules
-- The root `manifest.yml` is the source of truth for traversal; importers should follow `ref` to load `pack.yml`.
-- `pages` entries are relative to the directory containing `pack.yml`.
-- Importers may optionally validate structure using schemas under `schema/`.
+In v1, the root manifest referenced directory-level `pack.yml` files, which in turn referenced file paths and titles. v2 centralizes page metadata into a flat registry and references titles from packs. During migration, tooling can read v1 and emit v2 with the same titles and files.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,6 +5,7 @@
 LabkiPackManager integrates the `labki-packs` repository with MediaWiki 1.44 to import predefined wiki content (layouts, templates, forms) stored as `.wiki`/`.md` files. The upstream packs repo is `Aharoni-Lab/labki-packs` on GitHub.
 
 ### Key objectives
+
 - Minimal MediaWiki extension structure visible on `Special:Version`. [Implemented]
 - Special page `Special:LabkiPackManager` for admins. [Implemented]
 - Fetch and parse root YAML manifest and display packs. [Implemented]
@@ -13,6 +14,7 @@ LabkiPackManager integrates the `labki-packs` repository with MediaWiki 1.44 to 
 - Plan for exporting changes back to the repo via PRs.
 
 ## Current Status
+
 - Root manifest fetching via HTTP and YAML parsing implemented.
 - Cached storage and refresh flow implemented.
 - `Special:LabkiPackManager` lists available packs.
@@ -34,7 +36,7 @@ LabkiPackManager integrates the `labki-packs` repository with MediaWiki 1.44 to 
 
 ### Example
 
-```
+```text
 packs/
 
 ├─ lab-operations/
@@ -89,7 +91,6 @@ packs:
     description: Lab operations content
     pages:
       - Template:Microscope
-      - Form:Microscope
     children:
       equipment:
         description: Equipment-related packs
@@ -111,47 +112,56 @@ packs:
 ## Steps
 
 ### Step 1: Bare-Bones Extension
+
 - Directory: `extensions/LabkiPackManager/`
 - Files: `extension.json`, `includes/`, `i18n/`, `README.md`
 - Registration: `wfLoadExtension( 'LabkiPackManager' );`
 - Verify on `Special:Version`.
 
 ### Step 2: Special Page (LabkiPackManager)
+
 - Class: `LabkiPackManager\\Special\\SpecialLabkiPackManager` extending `SpecialPage`.
 - Register via `extension.json` `SpecialPages`.
 - Placeholder output confirming page loads.
 
 ### Step 3: Fetch Manifest (Implemented)
+
 - Config: `LabkiContentManifestURL` (exposed as `$wgLabkiContentManifestURL`).
 - Use MediaWiki HTTP facilities; parse YAML; handle errors.
 - Future: recursively fetch folder-level manifests.
 
 ### Step 4: List Packs (UI) (Implemented)
+
 - Render a form listing packs with checkboxes and CSRF token.
 - Refresh control for re-fetch and cache.
 - On POST, capture selected pack IDs for import.
 
 ### Step 5: Import `.wiki` Packs
+
 - Config: `LabkiContentBaseURL` to construct raw file URLs.
 - For each selected pack, fetch `pack.yml`, then fetch each file under `<pack>/pages/`.
 - Save text via `WikiPageFactory` / `PageUpdater`.
 - Provide success/error feedback per pack.
 
 ### Step 6: Permissions & Security
+
 - Define `labkipackmanager-manage` right; grant to `sysop` by default.
 - Restrict `Special:LabkiPackManager` accordingly.
 - Validate POST token and selected IDs against the manifest.
 
 ### Step 7: Future Export & PRs
+
 - Export selected pages’ wikitext.
 - Commit to a new branch using GitHub REST API with `$wgLabkiGitHubToken`.
 - Open a pull request and link back.
 
 ### Step 8: Testing & Docs
+
 - PHPUnit tests for manifest parsing and import routines.
 - GitHub Actions CI for PHPCS and PHPUnit.
 - Expand README with Docker clone instructions and configuration.
 
 ## Docker Integration
+
 - Clone this repository in your MediaWiki image build or bind mount under `extensions/LabkiPackManager`.
 - Add `wfLoadExtension( 'LabkiPackManager' );` to `LocalSettings.php`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,17 +22,15 @@ LabkiPackManager integrates the `labki-packs` repository with MediaWiki 1.44 to 
 
 `labki-packs/` (GitHub: `Aharoni-Lab/labki-packs`)
 
-- `manifest.yml` – global hierarchical registry of packs with refs to pack.yml
+- `manifest.yml` – v2 flat pages registry + hierarchical packs
 - `README.md` – overview of how to use/update packs
-- `schema/` – optional JSON/YAML schemas for validation
-- `packs/` – all content organized here
+- `schema/` – JSON/YAML schemas for validation
+- `pages/` – flat directory of page files (optionally grouped by type)
 
-### Packs layout
+### Pages and packs layout (v2)
 
-Inside `packs/`, use a directory hierarchy that mirrors logical grouping.
-
-- Any node in the hierarchy can contain a `pages/` folder with plain `.wiki` or `.md` files.
-- Leaves are individual packs, each with their own `pack.yml` (name, version, dependencies, pages).
+- All page files live under the top-level `pages/` directory (flat). You may group by type for convenience.
+- Packs are logical groups defined in the root `manifest.yml` under `packs`, referencing page titles from the global `pages` registry.
 
 ### Example
 
@@ -70,66 +68,38 @@ packs/
         └─ pages/...
 ```
 
-### Root-level manifest example (manifest.yml)
+### Root-level manifest example (manifest.yml, v2)
 
 ```yaml
-version: 1.0.0
+version: 2.0.0
 last_updated: 2025-09-22
+
+pages:
+  Template:Microscope:
+    file: pages/Templates/Template_Microscope.wiki
+    type: template
+    version: 1.0.0
+  Form:Microscope:
+    file: pages/Forms/Form_Microscope.wiki
+    type: form
+    version: 1.0.0
 
 packs:
   lab-operations:
-    ref: packs/lab-operations/pack.yml
+    description: Lab operations content
+    pages:
+      - Template:Microscope
+      - Form:Microscope
     children:
       equipment:
-        ref: packs/lab-operations/equipment/pack.yml
-        children:
-          calibration:
-            ref: packs/lab-operations/equipment/calibration/pack.yml
-            children:
-              microscope_pack:
-                ref: packs/lab-operations/equipment/calibration/microscope_pack/pack.yml
-              scale_pack:
-                ref: packs/lab-operations/equipment/calibration/scale_pack/pack.yml
-          maintenance_pack:
-            ref: packs/lab-operations/equipment/maintenance_pack/pack.yml
-      training_pack:
-        ref: packs/lab-operations/training_pack/pack.yml
-
-  tool-development:
-    ref: packs/tool-development/pack.yml
-    children:
-      imaging:
-        ref: packs/tool-development/imaging/pack.yml
-        children:
-          miniscope_pack:
-            ref: packs/tool-development/imaging/miniscope_pack/pack.yml
-      acquisition_pack:
-        ref: packs/tool-development/acquisition_pack/pack.yml
+        description: Equipment-related packs
+        pages: []
 ```
 
-### pack.yml (per-pack metadata) examples
+### v1 vs v2
 
-Example parent pack: `packs/lab-operations/pack.yml`
-
-```yaml
-name: lab-operations
-version: 2.1.0
-description: "Guides and procedures for day-to-day lab operations."
-pages:
-  - pages/safety_overview.wiki
-  - pages/general_policies.wiki
-dependencies: []
-```
-
-Example leaf or intermediate pack: `packs/tool-development/imaging/pack.yml`
-
-```yaml
-name: imaging
-version: 2.0.0
-description: "Imaging-related tools and methods."
-pages: []
-dependencies: []
-```
+- v1: per-directory `pack.yml` files and nested `packs/` structure.
+- v2: flat global `pages` registry in root manifest; packs reference titles and define hierarchy in the manifest.
 
 ### Notes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,11 +1,13 @@
 ﻿# Usage with LabkiPackManager
 
 ## Configure
+
 - Set `$wgLabkiContentManifestURL` to the raw URL for this repository's `manifest.yml`.
 - Set `$wgLabkiContentBaseURL` to the base raw URL for repository files.
 - Ensure your admin account has `labkipackmanager-manage` rights (granted to `sysop` by default).
 
 ## Import packs
+
 1. Visit `Special:LabkiPackManager`.
 2. Click Refresh to fetch the latest manifest and cache it.
 3. Browse the tree and select packs to import.
@@ -13,15 +15,18 @@
 5. Review success and error messages for each pack.
 
 ## How import works (v2)
+
 - The extension fetches `manifest.yml` and reads the global `pages` registry and `packs` tree.
 - When you select a pack, the importer resolves each title in `packs.*.pages[]` to its file via the `pages` registry.
 - Content is fetched from `pages.*.file` and saved directly to the canonical title (no XML).
 
 ## Updating and removal
+
 - To update, bump `pages.*.version` as appropriate and re-import the pack.
 - Removal may require manual cleanup unless the extension provides uninstall flows.
 
 ## Troubleshooting
+
 - Ensure YAML is valid; validate with `schema/` if provided.
 - Verify the base URLs and network access.
 - Check permissions and CSRF token validity.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 ## Configure
 - Set `$wgLabkiContentManifestURL` to the raw URL for this repository's `manifest.yml`.
-- Set `$wgLabkiContentBaseURL` to the base raw URL for pack files.
+- Set `$wgLabkiContentBaseURL` to the base raw URL for repository files.
 - Ensure your admin account has `labkipackmanager-manage` rights (granted to `sysop` by default).
 
 ## Import packs
@@ -12,17 +12,13 @@
 4. Submit to start the import.
 5. Review success and error messages for each pack.
 
-## How import works
-- The extension fetches `pack.yml` for each selected node and traverses `pages:` entries.
-- For each page entry:
-  - If `title` is present, that becomes the wiki page title.
-  - Else if `namespace` and `name` are present, the title is `Namespace:Name`.
-  - Else if the file starts with `<!-- Title: Namespace:Name -->`, that title is used.
-  - Else a heuristic derives a title from the filename (e.g., `Template_` -> `Template:`).
-- The content is saved directly to the wiki (no XML). Existing pages are updated.
+## How import works (v2)
+- The extension fetches `manifest.yml` and reads the global `pages` registry and `packs` tree.
+- When you select a pack, the importer resolves each title in `packs.*.pages[]` to its file via the `pages` registry.
+- Content is fetched from `pages.*.file` and saved directly to the canonical title (no XML).
 
 ## Updating and removal
-- To update, pull the latest manifest and re-import the same pack.
+- To update, bump `pages.*.version` as appropriate and re-import the pack.
 - Removal may require manual cleanup unless the extension provides uninstall flows.
 
 ## Troubleshooting

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ﻿version: 2.0.0
-last_updated: 2025-09-22
+last_updated: "2025-09-22"
 
 pages: {}
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+﻿version: 2.0.0
+last_updated: 2025-09-22
+
+pages: {}
+
+packs: {}

--- a/schema/pack.schema.json
+++ b/schema/pack.schema.json
@@ -1,0 +1,13 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["name", "version", "description", "pages", "dependencies"],
+  "properties": {
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "description": { "type": "string" },
+    "dependencies": { "type": "array", "items": { "type": "string" } },
+    "pages": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/schema/pack.schema.json
+++ b/schema/pack.schema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "required": ["name", "version", "description", "pages", "dependencies"],

--- a/schema/root-manifest.schema.json
+++ b/schema/root-manifest.schema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "required": ["version", "pages", "packs"],

--- a/schema/root-manifest.schema.json
+++ b/schema/root-manifest.schema.json
@@ -1,0 +1,39 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["version", "pages", "packs"],
+  "properties": {
+    "version": { "type": "string" },
+    "last_updated": { "type": "string" },
+    "pages": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["file", "type", "version"],
+        "properties": {
+          "file": { "type": "string" },
+          "type": { "type": "string", "enum": ["template", "form", "category", "property", "layout", "other"] },
+          "version": { "type": "string" },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "packs": { "$ref": "#/$defs/packNodeMap" }
+  },
+  "$defs": {
+    "packNodeMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "description": { "type": "string" },
+          "pages": { "type": "array", "items": { "type": "string" } },
+          "children": { "$ref": "#/$defs/packNodeMap" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_repo.py
+++ b/tools/validate_repo.py
@@ -1,0 +1,222 @@
+﻿#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+
+def load_yaml(path: Path):
+    with path.open('r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def load_json(path: Path):
+    with path.open('r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def validate_with_schema(data, schema):
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    return errors
+
+
+def error(msg):
+    print(f"ERROR: {msg}")
+
+
+def warn(msg):
+    print(f"WARNING: {msg}")
+
+
+def check_root_manifest(manifest_path: Path, schema_path: Path) -> int:
+    rc = 0
+    try:
+        manifest = load_yaml(manifest_path)
+    except Exception as e:
+        error(f"Failed to read root manifest {manifest_path}: {e}")
+        return 1
+
+    try:
+        schema = load_json(schema_path)
+    except Exception as e:
+        error(f"Failed to read schema {schema_path}: {e}")
+        return 1
+
+    schema_errors = validate_with_schema(manifest, schema)
+    if schema_errors:
+        for e in schema_errors:
+            error(f"Schema validation: {e.message} at path {list(e.path)}")
+        rc = 1
+
+    # v2: validate flat pages registry
+    pages = manifest.get('pages', {})
+    if not isinstance(pages, dict):
+        error("'pages' must be a mapping of titles to objects")
+        rc = 1
+    else:
+        for title, meta in pages.items():
+            if ':' not in title:
+                warn(f"Title missing namespace: {title}")
+            file_rel = meta.get('file')
+            if not file_rel:
+                error(f"Page '{title}' missing file path")
+                rc = 1
+                continue
+            if ':' in os.path.basename(file_rel):
+                error(f"Filename must not contain colon: {file_rel} (for {title})")
+                rc = 1
+            abs_path = (manifest_path.parent / file_rel).resolve()
+            if not abs_path.exists():
+                error(f"Page file not found: {file_rel} (for {title})")
+                rc = 1
+
+    def recurse(node_map):
+        nonlocal rc
+        if not isinstance(node_map, dict):
+            error("packs must be a mapping")
+            rc = 1
+            return
+        for key, node in node_map.items():
+            pages_list = node.get('pages', [])
+            if pages_list and not isinstance(pages_list, list):
+                error(f"Node '{key}' pages must be an array")
+                rc = 1
+            for title in pages_list or []:
+                if title not in pages:
+                    error(f"Node '{key}' references unknown page title: {title}")
+                    rc = 1
+            children = node.get('children')
+            if children is not None:
+                recurse(children)
+
+    recurse(manifest.get('packs', {}))
+    return rc
+
+
+TITLE_COMMENT_RE = re.compile(r"^\s*<!--\s*Title:\s*(.+?)\s*-->\s*$")
+
+
+def derive_title_from_filename(filename: str):
+    base = os.path.basename(filename)
+    name, _sep, _ext = base.partition('.')
+    for ns in ['Template_', 'Form_', 'Category_', 'Property_']:
+        if name.startswith(ns):
+            rest = name[len(ns):]
+            rest = rest.replace('_', ' ')
+            return f"{ns[:-1]}:{rest}"
+    # default: just use filename without extension
+    return name.replace('_', ' ')
+
+
+def resolve_title(entry, file_path: Path):
+    if isinstance(entry, dict):
+        if 'title' in entry and entry['title']:
+            return entry['title'], []
+        if entry.get('namespace') and entry.get('name'):
+            return f"{entry['namespace']}:{entry['name']}", []
+    # Try file comment
+    try:
+        with file_path.open('r', encoding='utf-8') as f:
+            first_line = f.readline().strip()
+            m = TITLE_COMMENT_RE.match(first_line)
+            if m:
+                return m.group(1), []
+    except Exception:
+        pass
+    # Fallback to heuristic, warn
+    return derive_title_from_filename(file_path.name), [f"Heuristic title used for {file_path}"]
+
+
+def validate_packs(packs_root: Path, schema_path: Path) -> int:
+    rc = 0
+    schema = load_json(schema_path)
+
+    pack_files = list(packs_root.rglob('pack.yml'))
+    if not pack_files:
+        warn(f"No pack.yml found under {packs_root}")
+
+    for pack_file in pack_files:
+        try:
+            pack = load_yaml(pack_file)
+        except Exception as e:
+            error(f"Failed to read {pack_file}: {e}")
+            rc = 1
+            continue
+        schema_errors = validate_with_schema(pack, schema)
+        if schema_errors:
+            for e in schema_errors:
+                error(f"Schema {pack_file}: {e.message} at path {list(e.path)}")
+            rc = 1
+            continue
+        pack_dir = pack_file.parent
+        pages = pack.get('pages', [])
+        for entry in pages:
+            if isinstance(entry, str):
+                rel = entry
+            elif isinstance(entry, dict):
+                rel = entry.get('file')
+                if not rel:
+                    error(f"{pack_file}: page object missing 'file'")
+                    rc = 1
+                    continue
+            else:
+                error(f"{pack_file}: invalid page entry type {type(entry)}")
+                rc = 1
+                continue
+
+            if ':' in os.path.basename(rel):
+                error(f"Filename must not contain colon: {rel} in {pack_file}")
+                rc = 1
+                continue
+            if not rel.replace('\\', '/').startswith('pages/'):
+                error(f"Page path must be under 'pages/': {rel} in {pack_file}")
+                rc = 1
+                continue
+
+            abs_path = (pack_dir / rel).resolve()
+            if not abs_path.exists():
+                error(f"Referenced page not found: {rel} (in {pack_file})")
+                rc = 1
+                continue
+
+            title, warnings = resolve_title(entry, abs_path)
+            for w in warnings:
+                warn(w)
+
+            # Additional semantic checks
+            if title.startswith('Property:'):
+                content = abs_path.read_text(encoding='utf-8', errors='ignore')
+                if '[[Has type::' not in content:
+                    warn(f"Property page without explicit type: {abs_path}")
+
+    return rc
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Validate labki-packs repository')
+    sub = parser.add_subparsers(dest='cmd', required=True)
+
+    p_root = sub.add_parser('validate-root', help='Validate root manifest')
+    p_root.add_argument('manifest', type=str)
+    p_root.add_argument('schema', type=str)
+
+    p_packs = sub.add_parser('validate-packs', help='Validate pack manifests and pages')
+    p_packs.add_argument('packs_root', type=str)
+    p_packs.add_argument('schema', type=str)
+
+    args = parser.parse_args()
+
+    if args.cmd == 'validate-root':
+        sys.exit(check_root_manifest(Path(args.manifest), Path(args.schema)))
+    if args.cmd == 'validate-packs':
+        sys.exit(validate_packs(Path(args.packs_root), Path(args.schema)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Move to a model where all page files live in a flat top-level pages/ directory (optionally grouped by type subfolders).
- Introduce a global pages registry in manifest.yml that maps canonical wiki titles (e.g., Template:Microscope) to repository files and per-page versions.
- Define packs only in the root manifest.yml under packs, referencing titles from the global pages registry (no per-directory pack.yml).
- Update docs, schemas, validator, and CI to enforce this structure.

## Follow-ups
- Add additional page types or metadata as needed (e.g., owners, tags).

## Checklist
- [x] Docs updated (README.md, docs/*)
- [x] Schemas updated (schema/root-manifest.schema.json)
- [x] Validator updated (	ools/validate_repo.py)
- [x] CI added (.github/workflows/ci.yml + linters configs)
