### PR TITLE
Update docs and schema for a flat packs structure

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -4,7 +4,8 @@
 
 - All page files live under the top-level `pages/` directory.
 - Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`.
-- Packs are defined only in the root `manifest.yml` under `packs` and reference titles from the global `pages` registry.
+- Packs are defined in the root `manifest.yml` under a flat `packs` registry with `version`, `pages` (titles), and `depends_on` (other packs).
+- Optional `groups` provide hierarchical navigation for the UI and reference pack ids.
 - Use `.wiki` for wikitext content and `.md` for Markdown content.
 
 ## Filenames and titles

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -13,11 +13,18 @@ Fields:
     - `type` (string): one of `template|form|category|property|layout|other`
     - `version` (string): semantic version for this page
     - `description` (string, optional)
-- `packs` (mapping): hierarchical tree of packs
-  - Each key is a node id; value has:
+- `packs` (mapping): flat registry of packs
+  - Each key is a pack id; value has:
     - `description` (string, optional)
-    - `pages` (array of strings): list of page titles from the global `pages` registry
-    - `children` (mapping, optional): nested packs with same structure
+    - `version` (string, required): semantic version for the pack
+    - `pages` (array of strings): page titles from the global `pages` registry
+    - `depends_on` (array of strings, optional): other pack ids this pack depends on
+    - `tags` (array of strings, optional)
+- `groups` (mapping, optional): hierarchical grouping for UI navigation
+  - Each key is a group id; value has:
+    - `description` (string, optional)
+    - `packs` (array of strings): pack ids included in this group
+    - `children` (mapping, optional): nested group nodes
 
 Example:
 
@@ -32,14 +39,16 @@ pages:
     version: 1.0.0
 
 packs:
-  lab-operations:
-    description: Lab operations content
-    pages:
-      - Template:Microscope
-    children:
-      equipment:
-        description: Equipment-related packs
-        pages: []
+  imaging:
+    description: Imaging templates and forms
+    version: 1.0.0
+    pages: [Template:Microscope]
+    depends_on: []
+
+groups:
+  operations:
+    description: Operational packs
+    packs: [imaging]
 ```
 
 ## Title resolution and filenames

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,14 +10,14 @@
 
 1. Visit `Special:LabkiPackManager`.
 2. Click Refresh to fetch the latest manifest and cache it.
-3. Browse the tree and select packs to import.
+3. Browse groups (if any) or the packs registry and select packs to import.
 4. Submit to start the import.
 5. Review success and error messages for each pack.
 
 ## How import works (v2)
 
-- The extension fetches `manifest.yml` and reads the global `pages` registry and `packs` tree.
-- When you select a pack, the importer resolves each title in `packs.*.pages[]` to its file via the `pages` registry.
+- The extension fetches `manifest.yml` and reads the global `pages` registry and the flat `packs` registry.
+- When you select a pack, the importer computes the transitive closure of `depends_on` and resolves each pack's `pages[]` titles via the `pages` registry.
 - Content is fetched from `pages.*.file` and saved directly to the canonical title (no XML).
 
 ## Updating and removal

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,5 @@ last_updated: "2025-09-22"
 pages: {}
 
 packs: {}
+
+groups: {}

--- a/schema/root-manifest.schema.json
+++ b/schema/root-manifest.schema.json
@@ -19,10 +19,11 @@
         "additionalProperties": false
       }
     },
-    "packs": { "$ref": "#/$defs/packNodeMap" }
+    "packs": { "$ref": "#/$defs/packRegistry" },
+    "groups": { "$ref": "#/$defs/groupNodeMap" }
   },
   "$defs": {
-    "packNodeMap": {
+    "packRegistry": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
@@ -30,9 +31,22 @@
           "description": { "type": "string" },
           "version": { "type": "string" },
           "pages": { "type": "array", "items": { "type": "string" } },
-          "children": { "$ref": "#/$defs/packNodeMap" }
+          "depends_on": { "type": "array", "items": { "type": "string" } },
+          "tags": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["version"],
+        "additionalProperties": false
+      }
+    },
+    "groupNodeMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "description": { "type": "string" },
+          "packs": { "type": "array", "items": { "type": "string" } },
+          "children": { "$ref": "#/$defs/groupNodeMap" }
+        },
         "additionalProperties": false
       }
     }


### PR DESCRIPTION
Make a shift to both flat pages and packs.

Packs can depend on other packs and there is an option groups for hierarchical display.