### PR TITLE
Validator and testing enhancements

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -4,9 +4,11 @@
 
 - All page files live under the top-level `pages/` directory.
 - Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`.
+ - Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`, `Modules/`.
 - Packs are defined in the root `manifest.yml` under a flat `packs` registry with `version`, `pages` (titles), and `depends_on` (other packs).
 - Optional `groups` provide hierarchical navigation for the UI and reference pack ids.
 - Use `.wiki` for wikitext content and `.md` for Markdown content.
+ - Lua modules use `.lua` files under `pages/Modules/` and titles in the `Module:` namespace.
 
 ## Filenames and titles
 
@@ -19,6 +21,12 @@
 - Templates (`Template:Name`) and forms (`Form:Name`) should be paired where applicable.
 - Semantic properties should declare types (e.g., `[[Has type::Text]]`).
 - Categories should include a concise description of scope and usage.
+
+## Modules, Help, MediaWiki
+
+- `module`: Use `Module:` namespace titles and store files under `pages/Modules/` with `.lua` extension.
+- `help`: Use `Help:` namespace titles for user-facing documentation.
+- `mediawiki`: Use `MediaWiki:` namespace titles for system messages; handle carefully due to site-wide impact.
 
 ## Versioning
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -3,12 +3,11 @@
 ## Layout (v2)
 
 - All page files live under the top-level `pages/` directory.
-- Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`.
- - Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`, `Modules/`.
+- Optional type subfolders: `Templates/`, `Forms/`, `Categories/`, `Properties/`, `Layouts/`, `Modules/`.
 - Packs are defined in the root `manifest.yml` under a flat `packs` registry with `version`, `pages` (titles), and `depends_on` (other packs).
 - Optional `groups` provide hierarchical navigation for the UI and reference pack ids.
 - Use `.wiki` for wikitext content and `.md` for Markdown content.
- - Lua modules use `.lua` files under `pages/Modules/` and titles in the `Module:` namespace.
+- Lua modules use `.lua` files under `pages/Modules/` and titles in the `Module:` namespace.
 
 ## Filenames and titles
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -26,6 +26,11 @@
 - Use semantic versioning (MAJOR.MINOR.PATCH).
 - Update `last_updated` when significant changes are merged.
 
+## Packs and shared pages
+
+- Do not duplicate the same page title in multiple packs. If two packs need the same page, move it into a common pack and reference it via `depends_on`.
+- Each pack's `pages` list must not contain duplicates (enforced by schema) and duplicates across packs are flagged by the validator.
+
 ## Style
 
 - Keep wikitext minimal and portable.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -10,7 +10,7 @@ Fields:
   - key: canonical wiki title (e.g., `Template:Microscope`)
   - value: object with fields:
     - `file` (string): repository path to the file under `pages/`
-    - `type` (string): one of `template|form|category|property|layout|other`
+    - `type` (string): one of `template|form|category|property|layout|module|help|mediawiki|other`
     - `version` (string): semantic version for this page
     - `description` (string, optional)
 - `packs` (mapping): flat registry of packs

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -19,12 +19,13 @@ Fields:
     - `version` (string, required): semantic version for the pack
     - `pages` (array of strings): page titles from the global `pages` registry
     - `depends_on` (array of strings, optional): other pack ids this pack depends on
-    - `tags` (array of strings, optional)
+    - `tags` (array of strings, optional): free-form labels to aid discovery/filtering (e.g., `core`, `imaging`)
 - `groups` (mapping, optional): hierarchical grouping for UI navigation
   - Each key is a group id; value has:
     - `description` (string, optional)
     - `packs` (array of strings): pack ids included in this group
     - `children` (mapping, optional): nested group nodes
+  - Best practice: list each pack in a single logical group; if a pack spans categories, use `tags` for cross-cutting labels.
 
 Example (aligned to repository samples; using `examples/manifest.yml`):
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,4 +32,4 @@
 - Ensure YAML is valid; validate with `schema/` if provided.
 - Verify the base URLs and network access.
 - Check permissions and CSRF token validity.
- - If a pack needs to fit multiple conceptual categories, prefer using `tags` in the manifest and future UI filtering rather than listing it in multiple groups.
+- If a pack needs to fit multiple conceptual categories, prefer using `tags` in the manifest and future UI filtering rather than listing it in multiple groups.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,8 @@
 1. Visit `Special:LabkiPackManager`.
 2. Click Refresh to fetch the latest manifest and cache it.
 3. Browse groups (if any) or the packs registry and select packs to import.
+   - Packs may appear under a single logical group for navigation.
+   - If a pack is not in any group, it still appears in the master list.
 4. Submit to start the import.
 5. Review success and error messages for each pack.
 
@@ -30,3 +32,4 @@
 - Ensure YAML is valid; validate with `schema/` if provided.
 - Verify the base URLs and network access.
 - Check permissions and CSRF token validity.
+ - If a pack needs to fit multiple conceptual categories, prefer using `tags` in the manifest and future UI filtering rather than listing it in multiple groups.

--- a/schema/root-manifest.schema.json
+++ b/schema/root-manifest.schema.json
@@ -13,7 +13,7 @@
         "properties": {
           "file": { "type": "string" },
           "type": { "type": "string", "enum": ["template", "form", "category", "property", "layout", "other"] },
-          "version": { "type": "string" },
+          "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
           "description": { "type": "string" }
         },
         "additionalProperties": false

--- a/schema/root-manifest.schema.json
+++ b/schema/root-manifest.schema.json
@@ -12,7 +12,7 @@
         "required": ["file", "type", "version"],
         "properties": {
           "file": { "type": "string" },
-          "type": { "type": "string", "enum": ["template", "form", "category", "property", "layout", "other"] },
+          "type": { "type": "string", "enum": ["template", "form", "category", "property", "layout", "module", "help", "mediawiki", "other"] },
           "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
           "description": { "type": "string" }
         },

--- a/schema/root-manifest.schema.json
+++ b/schema/root-manifest.schema.json
@@ -30,7 +30,7 @@
         "properties": {
           "description": { "type": "string" },
           "version": { "type": "string" },
-          "pages": { "type": "array", "items": { "type": "string" } },
+          "pages": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
           "depends_on": { "type": "array", "items": { "type": "string" } },
           "tags": { "type": "array", "items": { "type": "string" } }
         },

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -116,3 +116,25 @@ def test_validate_root_invalid_page_version(tmp_path):
     rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
     assert rc != 0
     assert 'must have semantic version' in out
+
+
+def test_validate_root_valid_page_version_passes(tmp_path):
+    manifest_yaml = textwrap.dedent(
+        '''
+        version: 2.0.0
+        pages:
+          Template:Example:
+            file: pages/Templates/Template_Example.wiki
+            type: template
+            version: 2.3.4
+        packs:
+          example:
+            version: 1.0.0
+            pages: [Template:Example]
+            depends_on: []
+        '''
+    ).strip() + "\n"
+    write_tmp(tmp_path, 'pages/Templates/Template_Example.wiki', '== Example ==\n')
+    manifest = write_tmp(tmp_path, 'manifest.yml', manifest_yaml)
+    rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
+    assert rc == 0, f"expected success, got rc={rc}, out={out}, err={err}"

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -180,3 +180,48 @@ def test_validate_root_warns_on_orphan_files(tmp_path):
     # should still be success (warning only) and include warning text
     assert rc == 0
     assert 'Orphan page file not referenced in manifest:' in out
+
+
+def test_validate_module_page_rules(tmp_path):
+    # Proper module: Module:Name, .lua under pages/Modules/
+    good_manifest = textwrap.dedent(
+        '''
+        version: 2.0.0
+        pages:
+          Module:Util:
+            file: pages/Modules/Module_Util.lua
+            type: module
+            version: 1.0.0
+        packs:
+          base:
+            version: 1.0.0
+            pages: [Module:Util]
+        '''
+    ).strip() + "\n"
+    write_tmp(tmp_path, 'pages/Modules/Module_Util.lua', '-- lua module\n')
+    manifest = write_tmp(tmp_path, 'manifest.yml', good_manifest)
+    rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
+    assert rc == 0
+
+    # Module with mismatched namespace/extension/dir should warn, not fail
+    bad_manifest = textwrap.dedent(
+        '''
+        version: 2.0.0
+        pages:
+          NotModule:Wrong:
+            file: pages/Templates/Module_Wrong.txt
+            type: module
+            version: 1.0.0
+        packs:
+          base:
+            version: 1.0.0
+            pages: [NotModule:Wrong]
+        '''
+    ).strip() + "\n"
+    write_tmp(tmp_path, 'pages/Templates/Module_Wrong.txt', 'placeholder\n')
+    manifest2 = write_tmp(tmp_path, 'manifest.yml', bad_manifest)
+    rc2, out2, err2 = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest2), str(SCHEMA)])
+    assert rc2 == 0
+    assert "Module type should use 'Module:' namespace" in out2
+    assert 'Module files should use .lua extension' in out2
+    assert 'Module files should be stored under pages/Modules/' in out2

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -225,3 +225,30 @@ def test_validate_module_page_rules(tmp_path):
     assert "Module type should use 'Module:' namespace" in out2
     assert 'Module files should use .lua extension' in out2
     assert 'Module files should be stored under pages/Modules/' in out2
+
+
+def test_validate_group_duplicate_pack_warns(tmp_path):
+    manifest_yaml = textwrap.dedent(
+        '''
+        version: 2.0.0
+        pages:
+          Template:Only:
+            file: pages/Templates/Template_Only.wiki
+            type: template
+            version: 1.0.0
+        packs:
+          one:
+            version: 1.0.0
+            pages: [Template:Only]
+        groups:
+          alpha:
+            packs: [one]
+          beta:
+            packs: [one]
+        '''
+    ).strip() + "\n"
+    write_tmp(tmp_path, 'pages/Templates/Template_Only.wiki', '== Only ==\n')
+    manifest = write_tmp(tmp_path, 'manifest.yml', manifest_yaml)
+    rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
+    assert rc == 0
+    assert "appears in multiple groups" in out

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -163,3 +163,20 @@ def test_validate_root_duplicate_page_across_packs_fails(tmp_path):
     rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
     assert rc != 0
     assert "included in multiple packs" in out
+
+
+def test_validate_root_warns_on_orphan_files(tmp_path):
+    # manifest has no pages, but file exists under pages/ -> expect WARNING
+    manifest_yaml = textwrap.dedent(
+        '''
+        version: 2.0.0
+        pages: {}
+        packs: {}
+        '''
+    ).strip() + "\n"
+    write_tmp(tmp_path, 'pages/Templates/Template_Orphan.wiki', '== Orphan ==\n')
+    manifest = write_tmp(tmp_path, 'manifest.yml', manifest_yaml)
+    rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
+    # should still be success (warning only) and include warning text
+    assert rc == 0
+    assert 'Orphan page file not referenced in manifest:' in out

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -93,3 +93,26 @@ def test_validate_root_bad_group_reference(tmp_path):
     rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
     assert rc != 0
     assert 'references unknown pack id' in out
+
+
+def test_validate_root_invalid_page_version(tmp_path):
+    manifest_yaml = textwrap.dedent(
+        '''
+        version: 2.0.0
+        pages:
+          Template:Example:
+            file: pages/Templates/Template_Example.wiki
+            type: template
+            version: v1
+        packs:
+          example:
+            version: 1.0.0
+            pages: [Template:Example]
+        '''
+    ).strip() + "\n"
+    # create the file so only version format triggers error
+    tmp_page = write_tmp(tmp_path, 'pages/Templates/Template_Example.wiki', '== Example ==\n')
+    manifest = write_tmp(tmp_path, 'manifest.yml', manifest_yaml)
+    rc, out, err = run([sys.executable, str(VALIDATOR), 'validate-root', str(manifest), str(SCHEMA)])
+    assert rc != 0
+    assert 'must have semantic version' in out

--- a/tools/validate_repo.py
+++ b/tools/validate_repo.py
@@ -75,6 +75,10 @@ def check_root_manifest(manifest_path: Path, schema_path: Path) -> int:
             if not abs_path.exists():
                 error(f"Page file not found: {file_rel} (for {title})")
                 rc = 1
+            page_version = meta.get('version')
+            if not isinstance(page_version, str) or not re.match(r"^\d+\.\d+\.\d+$", page_version or ""):
+                error(f"Page '{title}' must have semantic version (MAJOR.MINOR.PATCH)")
+                rc = 1
 
     # v2 packs: flat registry with depends_on
     packs = manifest.get('packs', {})

--- a/tools/validate_repo.py
+++ b/tools/validate_repo.py
@@ -79,6 +79,22 @@ def check_root_manifest(manifest_path: Path, schema_path: Path) -> int:
             if not isinstance(page_version, str) or not re.match(r"^\d+\.\d+\.\d+$", page_version or ""):
                 error(f"Page '{title}' must have semantic version (MAJOR.MINOR.PATCH)")
                 rc = 1
+            # Additional type-specific checks
+            page_type = meta.get('type')
+            if page_type == 'module':
+                if not title.startswith('Module:'):
+                    warn(f"Module type should use 'Module:' namespace: {title}")
+                if not abs_path.suffix == '.lua':
+                    warn(f"Module files should use .lua extension: {file_rel}")
+                # recommend Modules directory
+                if 'Modules' not in file_rel.replace('\\', '/'):
+                    warn(f"Module files should be stored under pages/Modules/: {file_rel}")
+            if page_type == 'help':
+                if not title.startswith('Help:'):
+                    warn(f"Help type should use 'Help:' namespace: {title}")
+            if page_type == 'mediawiki':
+                if not title.startswith('MediaWiki:'):
+                    warn(f"MediaWiki type should use 'MediaWiki:' namespace: {title}")
 
         # Orphan file detection: find files under pages/ not referenced in manifest
         referenced_abs_paths = set()


### PR DESCRIPTION
## Summary
This PR strengthens repository validation and expands the test suite. It enforces consistent versions, catches structural issues, and clarifies group/tag usage while adding first-class support for additional page types.

## Changes
- Enforce semantic page versions (MAJOR.MINOR.PATCH)
  - Schema: `pages.*.version` pattern
  - Validator: runtime check
- Prevent duplicate page titles across packs
  - Schema: `uniqueItems: true` within a pack
  - Validator: flags duplicates across multiple packs
- Orphan file detection
  - Warn on `.wiki`/`.md` under `pages/` not referenced in the manifest
- Additional page types
  - Schema: add `module`, `help`, `mediawiki`
  - Validator: guidance checks for `Module:` namespace, `.lua` under `pages/Modules/`, and Help/MediaWiki namespaces
- Group usage guidance
  - Validator: warn when a pack appears in multiple groups (suggest tags instead)

## Tests
- New and updated tests in `tests/test_validate_repo.py`:
  - Invalid and valid page version format
  - Duplicate page across packs
  - Orphan file warning
  - Module page rules (good case + warnings for mismatches)
  - Duplicate pack across groups warning

## CI
- `.github/workflows/ci.yml` runs:
  - Schema & repo validation (root and `examples/manifest.yml`)
  - Test suite via pytest
