### PR TITLE
Package schema in sdists and wheels, force schema resolution from schema_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,3 @@ jobs:
         run: python -m pip install --force-reinstall $(find ./dist -name "*.tar.gz")
       - name: Packaging tests - sdist
         run: pytest -m packaging --only-packaging
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,28 @@ jobs:
 
       - name: Run test suite
         run: pytest -q
+
+  packaging-tests:
+    name: Packaging tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install pdm and pytest
+        run: python -m pip install pdm pytest
+      - name: Build package
+        run: pdm build
+      - name: Install wheel
+        run: python -m pip install $(find ./dist -name "*.whl")
+      - name: Packaging tests - wheel
+        run: pytest -m packaging --only-packaging
+      - name: Install sdist
+        run: python -m pip install --force-reinstall $(find ./dist -name "*.tar.gz")
+      - name: Packaging tests - sdist
+        run: pytest -m packaging --only-packaging
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Sanity check — validate sample fixture
         run: |
-          labki-validate validate tests/fixtures/basic_repo/manifest.yml schema/v1_0_0/manifest.schema.json
+          labki-validate validate tests/fixtures/basic_repo/manifest.yml
 
       - name: Run test suite
         run: pytest -q
@@ -69,8 +69,8 @@ jobs:
       - name: Install wheel
         run: python -m pip install $(find ./dist -name "*.whl")
       - name: Packaging tests - wheel
-        run: pytest -m packaging --only-packaging
+        run: pytest -m packaging --with-packaging
       - name: Install sdist
         run: python -m pip install --force-reinstall $(find ./dist -name "*.tar.gz")
       - name: Packaging tests - sdist
-        run: pytest -m packaging --only-packaging
+        run: pytest -m packaging --with-packaging

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ htmlcov/
 node_modules/
 
 .pdm-build
+
+# ignore duplicated schema directory for editable installs
+src/labki_packs_tools/schema/

--- a/README.md
+++ b/README.md
@@ -53,19 +53,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: Aharoni-Lab/labki-packs-tools
-          path: tools-cache
+          path: labki-packs-tools
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install deps
-        run: pip install ./tools-cache
-      - name: Validate manifest (auto schema)
+        run: pip install ./labki-packs-tools
+      - name: Validate manifest
         run: |
-          # Auto schema selection based on manifest.schema_version
-          export LABKI_SCHEMA_DIR=$GITHUB_WORKSPACE/tools-cache/schema
           labki-validate validate manifest.yml --json
-      # Optional: validate with an explicit schema path (pin to a version)
-      - name: Validate manifest (explicit schema path)
-        run: |
-          labki-validate validate manifest.yml tools-cache/schema/v1_0_0/manifest.schema.json --json
 ```

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:eb4dfe4bcd90fa672177b35f3b41c83c8f8ce78a1e0900b5ab5c7ceb7b7d5bd9"
+content_hash = "sha256:252d998d7f1b97aa2d9f99c2d1c72792e30172fc26800d8ce499837e468ae370"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -89,7 +89,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 requires_python = ">=3.7"
 summary = "Backport of PEP 654 (exception groups)"
-groups = ["tests"]
+groups = ["dev", "tests"]
 marker = "python_version < \"3.11\""
 dependencies = [
     "typing-extensions>=4.6.0; python_version < \"3.13\"",
@@ -104,7 +104,7 @@ name = "iniconfig"
 version = "2.1.0"
 requires_python = ">=3.8"
 summary = "brain-dead simple config-ini parsing"
-groups = ["tests"]
+groups = ["dev", "tests"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -190,7 +190,7 @@ name = "pluggy"
 version = "1.6.0"
 requires_python = ">=3.9"
 summary = "plugin and hook calling mechanisms for python"
-groups = ["tests"]
+groups = ["dev", "tests"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -201,7 +201,7 @@ name = "pygments"
 version = "2.19.2"
 requires_python = ">=3.8"
 summary = "Pygments is a syntax highlighting package written in Python."
-groups = ["tests"]
+groups = ["dev", "tests"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -212,7 +212,7 @@ name = "pytest"
 version = "8.4.2"
 requires_python = ">=3.9"
 summary = "pytest: simple powerful testing with Python"
-groups = ["tests"]
+groups = ["dev", "tests"]
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Any
+
+
+def pdm_build_update_files(context: Any, files: dict[str, Path]) -> None:
+    """
+    Package schema in distributions
+    """
+    repo_dir = Path(__file__).parent
+    schema_dir = repo_dir / "schema"
+
+    for schema_file in schema_dir.glob("**/*.json"):
+        # prefix with src/labki_packs_tools so the schema end up in the package itself
+        # rather than the `site-packages` directory
+        files["src/labki_packs_tools/" + str(schema_file.relative_to(repo_dir))] = schema_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,8 @@ fixable = ["ALL"]
 target-version = ['py311', 'py312', 'py313']
 include = "(?:tests|src)/.*\\.py$"
 line-length = 100
+
+[tool.pytest.ini_options]
+markers = """
+  packaging: meta-tests that confirm equivalent behavior in editable/git installs, sdist, and wheels
+"""

--- a/src/labki_packs_tools/README.md
+++ b/src/labki_packs_tools/README.md
@@ -73,8 +73,6 @@ python -m labki_packs_tools.graph_repo tests/fixtures/basic_repo/manifest.yml --
 Auto schema selection (from another repo using this tool):
 
 ```powershell
-# Point to the schemas bundled with this package/repo
-$env:LABKI_SCHEMA_DIR = "$PWD\schema"
 labki-validate validate path\to\manifest.yml --json
 ```
 

--- a/src/labki_packs_tools/const.py
+++ b/src/labki_packs_tools/const.py
@@ -1,0 +1,27 @@
+import json
+from importlib.metadata import Distribution
+from pathlib import Path
+
+
+def _get_schema_dir() -> Path:
+    """
+    Get the schema directory
+
+    Gets the top-level repo-level schema if an editable installation from the git repository,
+    and otherwise uses the in-package version if installed from a wheel or sdist
+    """
+    # check if we are in editable mode,
+    # which is the only case where we would want to use the top-level schema directory
+    # (i.e. we are working on the code and would expect changes to the schema be reflected)
+    # See: https://github.com/pypa/setuptools/issues/4186
+    direct_url = Distribution.from_name("labki-packs-tools").read_text("direct_url.json")
+    is_editable = json.loads(direct_url).get("dir_info", {}).get("editable", False)
+
+    if is_editable:
+        return Path(__file__).parents[2] / "schema"
+    else:
+        return Path(__file__).parent / "schema"
+
+
+SCHEMA_DIR = _get_schema_dir()
+SCHEMA_INDEX = SCHEMA_DIR / "index.json"

--- a/src/labki_packs_tools/validation/__init__.py
+++ b/src/labki_packs_tools/validation/__init__.py
@@ -1,7 +1,7 @@
 """Validation framework for Labki content repositories."""
 
 # Optional: expose only the high-level API
-from .repo_schema_resolver import auto_resolve_schema
+from .repo_schema_resolver import resolve_schema
 from .repo_validator import validate_repo
 
-__all__ = ["validate_repo", "auto_resolve_schema"]
+__all__ = ["validate_repo", "resolve_schema"]

--- a/src/labki_packs_tools/validation/cli.py
+++ b/src/labki_packs_tools/validation/cli.py
@@ -15,13 +15,6 @@ def main() -> None:
     p_validate = sub.add_parser("validate", help="Validate a manifest")
     p_validate.add_argument("manifest", type=Path, help="Path to manifest.yml")
     p_validate.add_argument(
-        "schema",
-        type=str,
-        nargs="?",
-        default="auto",
-        help="Path to schema file or 'auto' (default)",
-    )
-    p_validate.add_argument(
         "--json",
         action="store_true",
         help="Output results as JSON instead of colored text",
@@ -30,7 +23,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.cmd == "validate":
-        rc, result = validate_repo(args.manifest, args.schema)
+        rc, result = validate_repo(args.manifest)
         if args.json:
             print_results_json(result)
         else:

--- a/src/labki_packs_tools/validation/repo_schema_resolver.py
+++ b/src/labki_packs_tools/validation/repo_schema_resolver.py
@@ -27,7 +27,7 @@ def resolve_schema(manifest: Path | str | dict) -> Path:
     explicit_schema = manifest.get("$schema")
     if isinstance(explicit_schema, str) and explicit_schema.strip():
         warnings.warn(
-            "Explicit $schema set, but validating from schema URI not supported yet. " "Ignoring.",
+            "Explicit $schema set, but validating from schema URI not supported yet. Ignoring.",
             stacklevel=2,
         )
 

--- a/src/labki_packs_tools/validation/repo_schema_resolver.py
+++ b/src/labki_packs_tools/validation/repo_schema_resolver.py
@@ -1,70 +1,42 @@
-import os
-import re
+import warnings
 from pathlib import Path
 
+from labki_packs_tools.const import SCHEMA_DIR, SCHEMA_INDEX
 from labki_packs_tools.utils import load_json, load_yaml
 
 
-def auto_resolve_schema(manifest_path: Path | str, schema_arg: Path | str = "auto") -> Path:
+def resolve_schema(manifest: Path | str | dict) -> Path:
     """
-    Determine which JSON Schema file to validate a manifest against.
+    Locate the correct schema for a manifest, as specified in its `schema_version` field
 
-    Resolution order:
-      1. If user passed a non-'auto' schema_arg, return it directly.
-      2. If manifest contains a `$schema` key, resolve that (absolute or relative).
-      3. Otherwise, look up the manifest's 'schema_version' in index.json under LABKI_SCHEMA_DIR
-         (or default to '<repo>/schema' if env var not set).
+    Args:
+        manifest (Path | str | dict): A path to a manifest, or an already-loaded manifest dict.
 
     Raises:
       ValueError: if schema cannot be resolved or found.
     """
-    manifest_path = Path(manifest_path)
-    if schema_arg != "auto":
-        schema_path = Path(schema_arg)
-        if not schema_path.exists():
-            raise ValueError(f"Schema path not found: {schema_path}")
-        return schema_path
+    if not isinstance(manifest, dict):
+        manifest_path = Path(manifest)
 
-    # 1️⃣ Load manifest so we can inspect $schema and schema_version
-    try:
-        manifest_data = load_yaml(manifest_path)
-    except Exception as e:
-        raise ValueError(f"Failed to read manifest: {e}") from e
+        try:
+            manifest = load_yaml(manifest_path)
+        except Exception as e:
+            raise ValueError(f"Failed to read manifest: {e}") from e
 
-    # 2️⃣ Case: manifest explicitly declares a $schema
-    explicit_schema = manifest_data.get("$schema")
+    # Warn when $schema is set while URI resolution is not implemented
+    explicit_schema = manifest.get("$schema")
     if isinstance(explicit_schema, str) and explicit_schema.strip():
-        schema_path = Path(explicit_schema)
-        if not schema_path.is_absolute():
-            schema_path = (manifest_path.parent / schema_path).resolve()
-        if not schema_path.exists():
-            raise ValueError(f"Explicit $schema file not found: {schema_path}")
-        return schema_path
+        warnings.warn(
+            "Explicit $schema set, but validating from schema URI not supported yet. " "Ignoring.",
+            stacklevel=2,
+        )
 
-    # 3️⃣ Case: manifest specifies schema_version (e.g. 1.0.0)
-    version_str = str(manifest_data.get("schema_version") or "").strip()
-    m = re.match(r"^(\d+)\.(\d+)\.(\d+)$", version_str)
-    if not m:
-        raise ValueError("Manifest 'schema_version' must be semantic (MAJOR.MINOR.PATCH)")
+    if "schema_version" not in manifest:
+        raise ValueError("No schema_version found in manifest.")
 
-    # 4️⃣ Find schema directory
-    schema_dir_env = os.environ.get("LABKI_SCHEMA_DIR")
-    # Default to repository layout when running from sources. This module lives under
-    # src/labki_packs_tools/validation/, so repo root is parents[3].
-    schema_dir = (
-        Path(schema_dir_env) if schema_dir_env else Path(__file__).resolve().parents[3] / "schema"
-    )
-
-    index_path = schema_dir / "index.json"
-    if not index_path.exists():
-        raise ValueError(f"Schema index not found: {index_path}")
-
-    try:
-        index = load_json(index_path)
-    except Exception as e:
-        raise ValueError(f"Failed to load schema index: {e}") from e
-
-    manifest_map = index.get("manifest") or {}
+    index = _read_index()
+    manifest_map = index["manifest"]
+    version_str = manifest["schema_version"]
     if version_str not in manifest_map:
         available = ", ".join(sorted([k for k in manifest_map if k != "latest"]))
         raise ValueError(
@@ -72,8 +44,20 @@ def auto_resolve_schema(manifest_path: Path | str, schema_arg: Path | str = "aut
         )
 
     schema_rel = manifest_map[version_str]
-    schema_path = (schema_dir / schema_rel).resolve()
+    schema_path = (SCHEMA_DIR / schema_rel).resolve()
     if not schema_path.exists():
-        raise ValueError(f"Resolved schema file does not exist: {schema_path}")
+        raise ValueError(
+            f"Schema version present in index, but schema path does not exist: {schema_path} "
+            "This is a bug in packaging, and you should report it!"
+        )
 
     return schema_path
+
+
+def _read_index() -> dict:
+    if not SCHEMA_INDEX.exists():
+        raise RuntimeError(
+            "The schema index was not found, the package was installed incorrectly,"
+            "or there is a bug in the packaging and you should raise an issue!"
+        )
+    return load_json(SCHEMA_INDEX)

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,13 @@
+from labki_packs_tools import const
+
+
+def test_schema_dir():
+    """
+    Mild duplicate of the version in test_schema_dir in test_packaging -
+    we want to test that the schema dir and accompanying consts
+    are correctly found even when installed in editable mode.
+
+    Just a mere test for existence, correctness and resolution is tested elsewhere
+    """
+    assert const.SCHEMA_DIR.exists()
+    assert const.SCHEMA_INDEX.exists()

--- a/tests/test_pack_validator.py
+++ b/tests/test_pack_validator.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from labki_packs_tools.validation.repo_validator import validate_repo
 
 
-def test_pack_cycle_detection(base_manifest, schema_v1: Path):
+def test_pack_cycle_detection(base_manifest):
     mpath = base_manifest(
         {
             "packs": {
@@ -14,45 +12,45 @@ def test_pack_cycle_detection(base_manifest, schema_v1: Path):
             }
         }
     )
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc != 0
     assert any("cycle" in e for e in result.errors)
 
 
-def test_pack_references_unknown_page(base_manifest, schema_v1: Path):
+def test_pack_references_unknown_page(base_manifest):
     mpath = base_manifest(
         {"packs": {"x": {"version": "1.0.0", "pages": ["Template:Missing"]}}, "pages": {}}
     )
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc != 0
     assert any("references unknown page" in e for e in result.errors)
 
 
-def test_pack_version_must_be_semver(base_manifest, schema_v1: Path):
+def test_pack_version_must_be_semver(base_manifest):
     mpath = base_manifest({"packs": {"p": {"version": "v1", "pages": []}}})
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc != 0
     assert any("semantic version" in e for e in result.errors)
 
 
-def test_depends_on_unknown_pack_id(base_manifest, schema_v1: Path):
+def test_depends_on_unknown_pack_id(base_manifest):
     mpath = base_manifest({"packs": {"p": {"version": "1.0.0", "pages": [], "depends_on": ["q"]}}})
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc != 0
     assert any("depends_on unknown pack id" in e for e in result.errors)
 
 
-def test_pack_pages_must_be_array(base_manifest, schema_v1: Path, tmp_page):
+def test_pack_pages_must_be_array(base_manifest, tmp_page):
     p = tmp_page(name="T")
     mpath = base_manifest(
         {"pages": {"Template:T": p}, "packs": {"p": {"version": "1.0.0", "pages": "Template:T"}}}
     )
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc != 0
     assert any("pages must be an array" in e for e in result.errors)
 
 
-def test_duplicate_page_across_packs(base_manifest, schema_v1: Path, tmp_page):
+def test_duplicate_page_across_packs(base_manifest, tmp_page):
     p = tmp_page(name="Shared")
     mpath = base_manifest(
         {
@@ -63,6 +61,6 @@ def test_duplicate_page_across_packs(base_manifest, schema_v1: Path, tmp_page):
             },
         }
     )
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc != 0
     assert any("included in multiple packs" in e for e in result.errors)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -17,7 +17,7 @@ def test_schema_dir():
     assert SCHEMA_INDEX.exists()
     with open(SCHEMA_INDEX) as jfile:
         index = json.load(jfile)
-    with open(SCHEMA_DIR / index["latest"]) as jfile:
+    with open(SCHEMA_DIR / index["manifest"]["latest"]) as jfile:
         latest = json.load(jfile)
 
     # boolean assert is enough here, we just want to confirm it contains something

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+pytestmark = pytest.mark.packaging
+
+
+def test_schema_dir():
+    """
+    Schema dir is within the site-packages directory rather than the repo root,
+    and it contains the schema
+    """
+    from labki_packs_tools.const import SCHEMA_DIR, SCHEMA_INDEX
+
+    assert "site-packages" in str(SCHEMA_DIR)
+    assert SCHEMA_DIR.exists()
+    assert SCHEMA_INDEX.exists()
+    with open(SCHEMA_INDEX) as jfile:
+        index = json.load(jfile)
+    with open(SCHEMA_DIR / index["latest"]) as jfile:
+        latest = json.load(jfile)
+
+    # boolean assert is enough here, we just want to confirm it contains something
+    assert latest

--- a/tests/test_repo_validator.py
+++ b/tests/test_repo_validator.py
@@ -10,14 +10,14 @@ from labki_packs_tools.validation.result_formatter import print_results, print_r
 from labki_packs_tools.validation.result_types import ValidationResult
 
 
-def test_valid_fixture_repo_passes(fixtures_repo: Path, schema_v1: Path):
+def test_valid_fixture_repo_passes(fixtures_repo: Path):
     manifest = fixtures_repo / "manifest.yml"
-    rc, result = validate_repo(manifest, schema_v1)
+    rc, result = validate_repo(manifest)
     assert rc == 0
     assert not result.errors
 
 
-def test_cli_parity_like_flow(base_manifest, schema_v1: Path, tmp_page):
+def test_cli_parity_like_flow(base_manifest, tmp_page):
     page = tmp_page(name="T")
     mpath = base_manifest(
         {
@@ -25,7 +25,7 @@ def test_cli_parity_like_flow(base_manifest, schema_v1: Path, tmp_page):
             "packs": {"p": {"version": "1.0.0", "pages": ["Template:T"]}},
         }
     )
-    rc, result = validate_repo(mpath, schema_v1)
+    rc, result = validate_repo(mpath)
     assert rc == 0, f"expected success, got rc={rc}, errors={result.errors}"
 
 


### PR DESCRIPTION
Having the schema in the repo root makes sense since it's not strictly speaking a source file, but that means that it won't be present in built sdists and wheels, which breaks the package, and forces installation to always be from the git repo (rather than pypi). 

This PR packages the schema directory in wheels and sdists, and single-sources the location of the schema dir. In doing so, I simplified the implementation so that manifests *always* use the schema version indicated in their `schema_version` field - a manifest should *always* be validated against its declared version.

- Adds a CI job to test the packaging both includes the schema dir and sets the associated consts correctly. Since these tests are special cases (testing packaging, rather than the package itself), they are not run by default, and the added `packaging-tests` job *only* runs tests marked with `packaging` (via the pytestmark module var)
- Removes the ability to specify a schema version by passing a path to a schema - this is the purpose of the `schema_version` field, and it should not be possible to introduce ambiguity in whether the schema is valid: the schema is valid if and only if it is valid according to the version it declares.
- Removes ability to specify location of schema dir via env var: it should not be possible to accidentally use incorrect or user-provided schemas, we should always use the packaged schemas.
- Changed the resolution of the schema from `$schema` to a "not implemented" warning - `$schema` must be a URI, and we should require that URI to be an http/s uri if present (not a local path), but that behavior is not implemented yet.
- Change failures to load the manifest or the schema into fatal errors (rather than validation errors) that fail further validation: it is not possible to validate a manifest if the manifest or the schema can't be located or are invalid json/yaml, so we should error immediately and fail validation rather than enter into an undefined state. Failures to load either of these files are different in kind than validation errors, which are errors with how the manifest is declared with respect to a schema.
- Allows an already-loaded manifest to be used when resolving schemas. this shoudl be done elsewhere too, but in general parsing yaml is expensive and we should only need to load the manifest once.
- Remove explicit passing of schema path in tests: we will want to test against multiple versions, rather than fixing that, or else all of our tests only tests old versions of the schema. We can do that by parameterizing the fixture, but we aren't there yet since we don't have multiple versions.
- Clarify error messages that can't be resolved by the user: when a bug is the result of packaging, the user can't do anything about it except raise an issue, so we should make that clear in error messages.
- Simplifies documentation: it shouldn't be necessary to set the location for the schema dir, it should be auto-detected