### PR TITLE
Ingest mediawiki exports

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,24 @@
 groups = ["default", "dev", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:252d998d7f1b97aa2d9f99c2d1c72792e30172fc26800d8ce499837e468ae370"
+content_hash = "sha256:f0c8c47bfa4ab342b2aa4aea46a76e93c8db7130084ef62d0d24c34df2ce8be5"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+requires_python = ">=3.8"
+summary = "Reusable constraint types to use with typing.Annotated"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.0.0; python_version < \"3.9\"",
+]
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
 
 [[package]]
 name = "attrs"
@@ -194,6 +208,131 @@ groups = ["dev", "tests"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.3"
+requires_python = ">=3.9"
+summary = "Data validation using Python type hints"
+groups = ["default"]
+dependencies = [
+    "annotated-types>=0.6.0",
+    "pydantic-core==2.41.4",
+    "typing-extensions>=4.14.1",
+    "typing-inspection>=0.4.2",
+]
+files = [
+    {file = "pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf"},
+    {file = "pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74"},
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+requires_python = ">=3.9"
+summary = "Core functionality for Pydantic validation and serialization"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.14.1",
+]
+files = [
+    {file = "pydantic_core-2.41.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2442d9a4d38f3411f22eb9dd0912b7cbf4b7d5b6c92c4173b75d3e1ccd84e36e"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:30a9876226dda131a741afeab2702e2d127209bde3c65a2b8133f428bc5d006b"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d55bbac04711e2980645af68b97d445cdbcce70e5216de444a6c4b6943ebcccd"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1d778fb7849a42d0ee5927ab0f7453bf9f85eef8887a546ec87db5ddb178945"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b65077a4693a98b90ec5ad8f203ad65802a1b9b6d4a7e48066925a7e1606706"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62637c769dee16eddb7686bf421be48dfc2fae93832c25e25bc7242e698361ba"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dfe3aa529c8f501babf6e502936b9e8d4698502b2cfab41e17a028d91b1ac7b"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca2322da745bf2eeb581fc9ea3bbb31147702163ccbcbf12a3bb630e4bf05e1d"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e8cd3577c796be7231dcf80badcf2e0835a46665eaafd8ace124d886bab4d700"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1cae8851e174c83633f0833e90636832857297900133705ee158cf79d40f03e6"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a26d950449aae348afe1ac8be5525a00ae4235309b729ad4d3399623125b43c9"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-win32.whl", hash = "sha256:0cf2a1f599efe57fa0051312774280ee0f650e11152325e41dfd3018ef2c1b57"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-win_amd64.whl", hash = "sha256:a8c2e340d7e454dc3340d3d2e8f23558ebe78c98aa8f68851b04dcb7bc37abdc"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:28ff11666443a1a8cf2a044d6a545ebffa8382b5f7973f22c36109205e65dc80"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61760c3925d4633290292bad462e0f737b840508b4f722247d8729684f6539ae"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eae547b7315d055b0de2ec3965643b0ab82ad0106a7ffd29615ee9f266a02827"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ef9ee5471edd58d1fcce1c80ffc8783a650e3e3a193fe90d52e43bb4d87bff1f"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15dd504af121caaf2c95cb90c0ebf71603c53de98305621b94da0f967e572def"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a926768ea49a8af4d36abd6a8968b8790f7f76dd7cbd5a4c180db2b4ac9a3a2"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6916b9b7d134bff5440098a4deb80e4cb623e68974a87883299de9124126c2a8"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5cf90535979089df02e6f17ffd076f07237efa55b7343d98760bde8743c4b265"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7533c76fa647fade2d7ec75ac5cc079ab3f34879626dae5689b27790a6cf5a5c"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:37e516bca9264cbf29612539801ca3cd5d1be465f940417b002905e6ed79d38a"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0c19cb355224037c83642429b8ce261ae108e1c5fbf5c028bac63c77b0f8646e"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win32.whl", hash = "sha256:09c2a60e55b357284b5f31f5ab275ba9f7f70b7525e18a132ec1f9160b4f1f03"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win_amd64.whl", hash = "sha256:711156b6afb5cb1cb7c14a2cc2c4a8b4c717b69046f13c6b332d8a0a8f41ca3e"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win_arm64.whl", hash = "sha256:6cb9cf7e761f4f8a8589a45e49ed3c0d92d1d696a45a6feaee8c904b26efc2db"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab06d77e053d660a6faaf04894446df7b0a7e7aba70c2797465a0a1af00fc887"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c53ff33e603a9c1179a9364b0a24694f183717b2e0da2b5ad43c316c956901b2"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:304c54176af2c143bd181d82e77c15c41cbacea8872a2225dd37e6544dce9999"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:025ba34a4cf4fb32f917d5d188ab5e702223d3ba603be4d8aca2f82bede432a4"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9f5f30c402ed58f90c70e12eff65547d3ab74685ffe8283c719e6bead8ef53f"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd96e5d15385d301733113bcaa324c8bcf111275b7675a9c6e88bfb19fc05e3b"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f348cbb44fae6e9653c1055db7e29de67ea6a9ca03a5fa2c2e11a47cff0e47"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec22626a2d14620a83ca583c6f5a4080fa3155282718b6055c2ea48d3ef35970"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3a95d4590b1f1a43bf33ca6d647b990a88f4a3824a8c4572c708f0b45a5290ed"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:f9672ab4d398e1b602feadcffcdd3af44d5f5e6ddc15bc7d15d376d47e8e19f8"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:84d8854db5f55fead3b579f04bda9a36461dab0730c5d570e1526483e7bb8431"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win32.whl", hash = "sha256:9be1c01adb2ecc4e464392c36d17f97e9110fbbc906bcbe1c943b5b87a74aabd"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win_amd64.whl", hash = "sha256:d682cf1d22bab22a5be08539dca3d1593488a99998f9f412137bc323179067ff"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win_arm64.whl", hash = "sha256:833eebfd75a26d17470b58768c1834dfc90141b7afc6eb0429c21fc5a21dcfb8"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1e5ab4fc177dd41536b3c32b2ea11380dd3d4619a385860621478ac2d25ceb00"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:3d88d0054d3fa11ce936184896bed3c1c5441d6fa483b498fac6a5d0dd6f64a9"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b2a054a8725f05b4b6503357e0ac1c4e8234ad3b0c2ac130d6ffc66f0e170e2"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0d9db5a161c99375a0c68c058e227bee1d89303300802601d76a3d01f74e258"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:6273ea2c8ffdac7b7fda2653c49682db815aebf4a89243a6feccf5e36c18c347"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:4c973add636efc61de22530b2ef83a65f39b6d6f656df97f678720e20de26caa"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b69d1973354758007f46cf2d44a4f3d0933f10b6dc9bf15cf1356e037f6f731a"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3619320641fd212aaf5997b6ca505e97540b7e16418f4a241f44cdf108ffb50d"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:491535d45cd7ad7e4a2af4a5169b0d07bebf1adfd164b0368da8aa41e19907a5"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:54d86c0cada6aba4ec4c047d0e348cbad7063b87ae0f005d9f8c9ad04d4a92a2"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca1124aced216b2500dc2609eade086d718e8249cb9696660ab447d50a758bd"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c9024169becccf0cb470ada03ee578d7348c119a0d42af3dcf9eda96e3a247c"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:26895a4268ae5a2849269f4991cdc97236e4b9c010e51137becf25182daac405"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:ca4df25762cf71308c446e33c9b1fdca2923a3f13de616e2a949f38bf21ff5a8"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5a28fcedd762349519276c36634e71853b4541079cab4acaaac60c4421827308"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c173ddcd86afd2535e2b695217e82191580663a1d1928239f877f5a1649ef39f"},
+    {file = "pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5"},
 ]
 
 [[package]]
@@ -533,8 +672,21 @@ version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
 groups = ["default", "dev", "tests"]
-marker = "python_version < \"3.13\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+requires_python = ">=3.9"
+summary = "Runtime typing introspection tools"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.12.0",
+]
+files = [
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
   "PyYAML>=6.0",
   "jsonschema>=4.18",
+  "pydantic>=2.12.3",
 ]
 
 [project.scripts]

--- a/src/labki_packs_tools/ingest.py
+++ b/src/labki_packs_tools/ingest.py
@@ -29,7 +29,7 @@ class ExportPage(BaseModel):
         Args:
             tree (ET.ElementTree): A `page` element from a mediawiki export
         """
-        title = tree.find("export:title", MW_XML_NS).text
+        name = tree.find("export:title", MW_XML_NS).text
 
         # find latest revision
         # revisions are usually exported in chronological order, ascending, but sort to be sure
@@ -39,7 +39,7 @@ class ExportPage(BaseModel):
 
         last_updated = _revision_timestamp(latest)
         content = latest.find("export:text", MW_XML_NS).text
-        return cls(title=title, last_updated=last_updated, content=content)
+        return cls(name=name, last_updated=last_updated, content=content)
 
     @property
     def safe_name(self) -> str:
@@ -47,6 +47,7 @@ class ExportPage(BaseModel):
         return re.sub(r"[^a-z0-9]", "_", self.name.lower()) + ".wiki"
 
     def write(self, path: Path) -> None:
+        path.parent.mkdir(exist_ok=True, parents=True)
         with open(path, "w", encoding="utf-8") as f:
             f.write(self.content)
 

--- a/src/labki_packs_tools/ingest.py
+++ b/src/labki_packs_tools/ingest.py
@@ -1,0 +1,85 @@
+import re
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from labki_packs_tools.manifest import Manifest
+from labki_packs_tools.types import UTCDateTime
+
+MW_XML_NS = {"export": "http://www.mediawiki.org/xml/export-0.11/"}
+"""
+Namespace prefixes for mediawiki exports
+
+See: https://docs.python.org/3/library/xml.etree.elementtree.html#parsing-xml-with-namespaces
+"""
+
+
+class ExportPage(BaseModel):
+    name: str
+    last_updated: UTCDateTime
+    content: str
+
+    @classmethod
+    def from_xml(cls, tree: ET.Element) -> "ExportPage":
+        """
+        Parse the content and timestamp from the latest revision of a mediawiki page export
+
+        Args:
+            tree (ET.ElementTree): A `page` element from a mediawiki export
+        """
+        title = tree.find("export:title", MW_XML_NS).text
+
+        # find latest revision
+        # revisions are usually exported in chronological order, ascending, but sort to be sure
+        revisions = tree.findall("export:revision", MW_XML_NS)
+        revisions = sorted(revisions, key=_revision_timestamp)
+        latest = revisions[-1]
+
+        last_updated = _revision_timestamp(latest)
+        content = latest.find("export:text", MW_XML_NS).text
+        return cls(title=title, last_updated=last_updated, content=content)
+
+    @property
+    def safe_name(self) -> str:
+        """name that is safe to use as a filename"""
+        return re.sub(r"[^a-z0-9]", "_", self.name.lower()) + ".wiki"
+
+    def write(self, path: Path) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self.content)
+
+
+def parse_export(path: Path) -> list[ExportPage]:
+    """
+    Parse a mediawiki export, returning the latest revision of each page.
+    """
+    tree = ET.parse(path)
+    pages = tree.getroot().findall("export:page", MW_XML_NS)
+    return [ExportPage.from_xml(page) for page in pages]
+
+
+def update_manifest(manifest_path: Path, export_path: Path) -> list[ExportPage]:
+    """
+    Update a manifest from a mediawiki export,
+    writing new or updated files,
+    and writing an updated copy of the manifest.
+
+    Returns:
+        The list of pages that were updated during the update operation
+    """
+    manifest_path = Path(manifest_path)
+    export_path = Path(export_path)
+    repo_dir = manifest_path.parent
+    manifest = Manifest.from_yaml(manifest_path)
+    updated = manifest.update_from_export(export_path, repo_dir)
+    if not updated:
+        return []
+    manifest.last_updated = datetime.now(UTC)
+    manifest.to_yaml(manifest_path)
+    return updated
+
+
+def _revision_timestamp(revision: ET.Element) -> UTCDateTime:
+    return datetime.fromisoformat(revision.find("./export:timestamp", MW_XML_NS).text)

--- a/src/labki_packs_tools/manifest.py
+++ b/src/labki_packs_tools/manifest.py
@@ -1,0 +1,61 @@
+"""
+Pydantic models for manipulating the manifest within the package.
+
+At the moment, the manually-created json schema is the
+source of truth for the manifest, and this is just for programmatic use.
+These models are thus *not* strictly validating,
+e.g. the fields don't have the correct regex patterns
+to avoid defining them twice in a conflicting way.
+
+see the `validation` subpackage.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated
+
+import yaml
+from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer
+
+
+def _to_utc(value: str | datetime) -> datetime:
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value)
+    value = value.replace(tzinfo=UTC)
+    return value
+
+
+def _to_isoformat(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+UTCDateTime = Annotated[datetime, BeforeValidator(_to_utc), PlainSerializer(_to_isoformat)]
+
+
+class ManifestPage(BaseModel):
+    file: str
+    last_updated: UTCDateTime
+    description: str | None = None
+
+
+class ManifestPack(BaseModel):
+    description: str | None = None
+    version: str
+    pages: list[str] = Field(default_factory=list)
+    depends_on: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+
+class Manifest(BaseModel):
+    schema_version: str = "1.0.0"
+    name: str
+    last_updated: UTCDateTime | None = None
+    pages: dict[str, ManifestPage] = Field(default_factory=dict)
+    packs: dict[str, ManifestPack] = Field(default_factory=list)
+
+    @classmethod
+    def from_yaml(cls, path: Path | str) -> "Manifest":
+        path = Path(path)
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return Manifest(**data)

--- a/src/labki_packs_tools/manifest.py
+++ b/src/labki_packs_tools/manifest.py
@@ -10,26 +10,12 @@ to avoid defining them twice in a conflicting way.
 see the `validation` subpackage.
 """
 
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated
 
 import yaml
-from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer
+from pydantic import BaseModel, Field
 
-
-def _to_utc(value: str | datetime) -> datetime:
-    if isinstance(value, str):
-        value = datetime.fromisoformat(value)
-    value = value.replace(tzinfo=UTC)
-    return value
-
-
-def _to_isoformat(value: datetime) -> str:
-    return value.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-UTCDateTime = Annotated[datetime, BeforeValidator(_to_utc), PlainSerializer(_to_isoformat)]
+from labki_packs_tools.types import UTCDateTime
 
 
 class ManifestPage(BaseModel):

--- a/src/labki_packs_tools/manifest.py
+++ b/src/labki_packs_tools/manifest.py
@@ -11,11 +11,15 @@ see the `validation` subpackage.
 """
 
 from pathlib import Path
+from typing import TYPE_CHECKING, Union
 
 import yaml
 from pydantic import BaseModel, Field
 
 from labki_packs_tools.types import UTCDateTime
+
+if TYPE_CHECKING:
+    from labki_packs_tools.ingest import ExportPage
 
 
 class ManifestPage(BaseModel):
@@ -45,3 +49,59 @@ class Manifest(BaseModel):
         with open(path) as f:
             data = yaml.safe_load(f)
         return Manifest(**data)
+
+    def to_yaml(self, path: Path | str) -> None:
+        dumped = self.model_dump(exclude_unset=True)
+        with open(path, "w") as f:
+            yaml.safe_dump(dumped, f)
+
+    def update_from_export(
+        self, export_path: Path | str, repo_dir: Path | str
+    ) -> list["ExportPage"]:
+        """
+        Update a manifest from a mediawiki export .xml file
+
+        Args:
+            export_path (Path | str): Path to the export .xml file
+            repo_dir (Path | str): Root directory that contains `manifest.yml` and `pages`
+
+        Returns:
+            A list of `ExportPage` objects for which the entry in the manifest was updated
+        """
+        from labki_packs_tools.ingest import parse_export
+
+        export_path = Path(export_path)
+        repo_dir = Path(repo_dir)
+        repo_dir.mkdir(exist_ok=True, parents=True)
+
+        pages = parse_export(export_path)
+        updated = []
+        for page in pages:
+            p = self._update_page(page, repo_dir)
+            if p is not None:
+                updated.append(p)
+        return updated
+
+    def _update_page(self, page: "ExportPage", repo_dir: Path | str) -> Union["ExportPage", None]:
+        """
+        Update a single page from an exported .xml file page,
+        writing the file if it doesn't exist or has been updated
+        since the last recorded update time
+        """
+        repo_dir = Path(repo_dir)
+        if page.name not in self.pages:
+            page_path = repo_dir / "pages" / page.safe_name
+            page.write(page_path)
+            self.pages[page.name] = ManifestPage(
+                file=str(page_path.relative_to(repo_dir)),
+                last_updated=page.last_updated,
+            )
+            return page
+        elif page.last_updated > self.pages[page.name].last_updated:
+            page_path = repo_dir / self.pages[page.name].file
+            page.write(page_path)
+            self.pages[page.name].last_updated = page.last_updated
+            return page
+        else:
+            # no update performed
+            return None

--- a/src/labki_packs_tools/types.py
+++ b/src/labki_packs_tools/types.py
@@ -1,0 +1,18 @@
+from datetime import datetime, UTC
+from typing import Annotated
+
+from pydantic import BeforeValidator, PlainSerializer
+
+
+def _to_utc(value: str | datetime) -> datetime:
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value)
+    value = value.replace(tzinfo=UTC)
+    return value
+
+
+def _to_isoformat(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+UTCDateTime = Annotated[datetime, BeforeValidator(_to_utc), PlainSerializer(_to_isoformat)]

--- a/src/labki_packs_tools/types.py
+++ b/src/labki_packs_tools/types.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Annotated
 
 from pydantic import BeforeValidator, PlainSerializer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,21 @@ def fixtures_repo(repo_root: Path) -> Path:
     return repo_root / "tests" / "fixtures" / "basic_repo"
 
 
+@pytest.fixture
+def test_data(repo_root: Path) -> Path:
+    return repo_root / "tests" / "data"
+
+
+@pytest.fixture
+def mediawiki_data(test_data: Path) -> Path:
+    return test_data / "mediawiki"
+
+
+@pytest.fixture
+def export_data(mediawiki_data: Path) -> Path:
+    return mediawiki_data / "export"
+
+
 # ────────────────────────────────────────────────────────────────
 # Helpers
 # ────────────────────────────────────────────────────────────────

--- a/tests/data/mediawiki/export/latest.xml
+++ b/tests/data/mediawiki/export/latest.xml
@@ -1,0 +1,271 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.11/ http://www.mediawiki.org/xml/export-0.11.xsd" version="0.11" xml:lang="en">
+  <siteinfo>
+    <sitename>Example Wiki</sitename>
+    <dbname>wikidb</dbname>
+    <base>https://wiki.example.com/Main_Page</base>
+    <generator>MediaWiki 1.39.1</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">Example Wiki</namespace>
+      <namespace key="5" case="first-letter">Example Wiki talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="102" case="first-letter">Property</namespace>
+      <namespace key="103" case="first-letter">Property talk</namespace>
+      <namespace key="106" case="first-letter">Form</namespace>
+      <namespace key="107" case="first-letter">Form talk</namespace>
+      <namespace key="108" case="first-letter">Concept</namespace>
+      <namespace key="109" case="first-letter">Concept talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>Category:Supply</title>
+    <ns>14</ns>
+    <id>1219</id>
+    <revision>
+      <id>4435</id>
+      <parentid>4434</parentid>
+      <timestamp>2025-10-17T22:41:57Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4435</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="2833" sha1="7ih5xo94wtqba8xjs55t3rjk82vm95p" xml:space="preserve">&lt;PageSchema&gt;
+  &lt;pageforms_Form name="Supply"&gt;
+    &lt;standardInputs inputFreeText="1" freeTextLabel="Free text"/&gt;
+  &lt;/pageforms_Form&gt;
+  &lt;Template name="Supply" format="standard"&gt;
+    &lt;pageforms_TemplateDetails/&gt;
+    &lt;semanticmediawiki_ConnectingProperty name=""/&gt;
+    &lt;Field name=""&gt;
+      &lt;pageforms_FormInput/&gt;
+      &lt;semanticmediawiki_Property name=""&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Name"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Name"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Description"&gt;
+      &lt;Label&gt;Description LABEL&lt;/Label&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;textarea&lt;/InputType&gt;
+        &lt;Description&gt;Description of the description field&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Description"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Price" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;USD (without $)&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Price"&gt;
+        &lt;Type&gt;Quantity&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Suppliers" list="list" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Supplier&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Supplied By"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Product ID"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Product ID"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Orders" display="hidden"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Purchase Order&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Order"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="URL"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has URL"&gt;
+        &lt;Type&gt;URL&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+  &lt;/Template&gt;
+&lt;/PageSchema&gt;
+
+An item that may be part of a standing inventory of lab supplies
+
+See also:
+
+* [[Template:Supply]]
+* [[Form:Supply]]</text>
+      <sha1>7ih5xo94wtqba8xjs55t3rjk82vm95p</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Template:Supply</title>
+    <ns>10</ns>
+    <id>1223</id>
+    <revision>
+      <id>4436</id>
+      <parentid>4428</parentid>
+      <timestamp>2025-10-17T22:42:31Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4436</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="774" sha1="74r0pr0u0j83bav7nb67mrelrwnlwf8" xml:space="preserve">&lt;noinclude&gt;
+{{#template_params:|Name (property=Has Name)|Description (label=Description LABEL;property=Has Description)|Price (property=Price;display=nonempty)|Suppliers (list;property=Supplied By;display=nonempty)|Product ID (property=Has Product ID)|Orders (property=Has Order;display=hidden)|URL (property=Has URL)}}
+&lt;/noinclude&gt;&lt;includeonly&gt;
+{| class="wikitable"
+|-
+! Name
+| [[Has Name::{{{Name|}}}]]
+|-
+! Description LABEL
+| [[Has Description::{{{Description|}}}]]
+{{#if:{{{Price|}}}|
+{{!}}-
+! Price
+{{!}} [[Price::{{{Price|}}}]]
+}}
+{{#if:{{{Suppliers|}}}|
+{{!}}-
+! Suppliers
+{{!}} {{#arraymap:{{{Suppliers|}}}|,|x|[[Supplied By::x]]}}
+
+}}
+|-
+! Product ID
+| [[Has Product ID::{{{Product ID|}}}]]
+|-
+! URL
+| [[Has URL::{{{URL|}}}]]
+|}
+
+[[Category:Supply]]
+&lt;/includeonly&gt;</text>
+      <sha1>74r0pr0u0j83bav7nb67mrelrwnlwf8</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Form:Supply</title>
+    <ns>106</ns>
+    <id>1222</id>
+    <revision>
+      <id>4431</id>
+      <parentid>4427</parentid>
+      <timestamp>2025-10-17T21:01:57Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4431</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="1372" sha1="kvpxtb6j4tpddh9eb6zln910b1iqoir" xml:space="preserve">&lt;noinclude&gt;
+This is the "Supply" form.
+To create a page with this form, enter the page name below;
+if a page with that name already exists, you will be sent to a form to edit that page.
+
+{{#forminput:form=Supply|autocomplete on category=Supply}}
+
+&lt;/noinclude&gt;&lt;includeonly&gt;
+&lt;div id="wikiPreview" style="display: none; padding-bottom: 25px; margin-bottom: 25px; border-bottom: 1px solid #AAAAAA;"&gt;&lt;/div&gt;
+{{{for template|Supply}}}
+{| class="formtable"
+! Name: 
+| {{{field|Name|input type=text}}}
+|-
+! Description LABEL: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;Description of the description field&lt;/p&gt;
+| {{{field|Description|input type=textarea}}}
+|-
+! Price: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;USD (without $)&lt;/p&gt;
+| {{{field|Price|input type=text}}}
+|-
+! Suppliers: 
+| {{{field|Suppliers|input type=text with autocomplete|values from category=Supplier}}}
+|-
+! Product ID: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/p&gt;
+| {{{field|Product ID|input type=text}}}
+|-
+! Orders: 
+| {{{field|Orders|input type=text with autocomplete|values from category=Purchase Order}}}
+|-
+! URL: 
+| {{{field|URL|input type=text}}}
+|}
+{{{end template}}}
+
+'''Free text:'''
+
+{{{standard input|free text|rows=10}}}
+&lt;/includeonly&gt;</text>
+      <sha1>kvpxtb6j4tpddh9eb6zln910b1iqoir</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Buffalo</title>
+    <ns>0</ns>
+    <id>1226</id>
+    <revision>
+      <id>4437</id>
+      <parentid>4432</parentid>
+      <timestamp>2025-10-17T22:43:26Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4437</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="221" sha1="gv772gh87fcluljod96w5yinubgeldn" xml:space="preserve">{{Supply
+|Name=Buffalonio Bites
+|Description=A nutritious snack heatable in the [[Microwave]]
+|Price=4.50
+|Suppliers=Buffaloni-o's
+|Product ID=1234-buf-z
+|URL=http://example.com/bz-crisps
+}}
+eifjserlifusrhlgiuh
+
+more text</text>
+      <sha1>gv772gh87fcluljod96w5yinubgeldn</sha1>
+    </revision>
+  </page>
+</mediawiki>

--- a/tests/data/mediawiki/export/revisions.xml
+++ b/tests/data/mediawiki/export/revisions.xml
@@ -1,0 +1,572 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.11/ http://www.mediawiki.org/xml/export-0.11.xsd" version="0.11" xml:lang="en">
+  <siteinfo>
+    <sitename>Example Wiki</sitename>
+    <dbname>wikidb</dbname>
+    <base>https://wiki.example.com/Main_Page</base>
+    <generator>MediaWiki 1.39.1</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">Example Wiki</namespace>
+      <namespace key="5" case="first-letter">Example Wiki talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="102" case="first-letter">Property</namespace>
+      <namespace key="103" case="first-letter">Property talk</namespace>
+      <namespace key="106" case="first-letter">Form</namespace>
+      <namespace key="107" case="first-letter">Form talk</namespace>
+      <namespace key="108" case="first-letter">Concept</namespace>
+      <namespace key="109" case="first-letter">Concept talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>Category:Supply</title>
+    <ns>14</ns>
+    <id>1219</id>
+    <revision>
+      <id>4424</id>
+      <timestamp>2025-10-17T20:55:19Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4424</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="2715" sha1="rcwt0681x75nkviuya4jlahxu2ft992" xml:space="preserve">&lt;PageSchema&gt;
+  &lt;pageforms_Form name="Supply"&gt;
+    &lt;standardInputs inputFreeText="1" freeTextLabel="Free text"/&gt;
+  &lt;/pageforms_Form&gt;
+  &lt;Template name="Supply" format="standard"&gt;
+    &lt;pageforms_TemplateDetails/&gt;
+    &lt;semanticmediawiki_ConnectingProperty name=""/&gt;
+    &lt;Field name=""&gt;
+      &lt;pageforms_FormInput/&gt;
+      &lt;semanticmediawiki_Property name=""&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Name"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Name"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Description"&gt;
+      &lt;Label&gt;Description LABEL&lt;/Label&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;textarea&lt;/InputType&gt;
+        &lt;Description&gt;Description of the description field&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Description"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Price" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;USD (without $)&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Price"&gt;
+        &lt;Type&gt;Quantity&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Suppliers" list="list" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Supplier&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Supplied By"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Product ID"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Product ID"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Orders" display="hidden"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Purchase Order&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Order"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="URL"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has URL"&gt;
+        &lt;Type&gt;URL&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+  &lt;/Template&gt;
+&lt;/PageSchema&gt;</text>
+      <sha1>rcwt0681x75nkviuya4jlahxu2ft992</sha1>
+    </revision>
+    <revision>
+      <id>4434</id>
+      <parentid>4424</parentid>
+      <timestamp>2025-10-17T22:41:35Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4434</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="2781" sha1="6b74ahbqktsg19qssy87mo7rz9hhs9t" xml:space="preserve">&lt;PageSchema&gt;
+  &lt;pageforms_Form name="Supply"&gt;
+    &lt;standardInputs inputFreeText="1" freeTextLabel="Free text"/&gt;
+  &lt;/pageforms_Form&gt;
+  &lt;Template name="Supply" format="standard"&gt;
+    &lt;pageforms_TemplateDetails/&gt;
+    &lt;semanticmediawiki_ConnectingProperty name=""/&gt;
+    &lt;Field name=""&gt;
+      &lt;pageforms_FormInput/&gt;
+      &lt;semanticmediawiki_Property name=""&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Name"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Name"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Description"&gt;
+      &lt;Label&gt;Description LABEL&lt;/Label&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;textarea&lt;/InputType&gt;
+        &lt;Description&gt;Description of the description field&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Description"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Price" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;USD (without $)&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Price"&gt;
+        &lt;Type&gt;Quantity&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Suppliers" list="list" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Supplier&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Supplied By"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Product ID"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Product ID"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Orders" display="hidden"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Purchase Order&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Order"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="URL"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has URL"&gt;
+        &lt;Type&gt;URL&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+  &lt;/Template&gt;
+&lt;/PageSchema&gt;
+
+An item that may be part of a standing inventory of lab supplies</text>
+      <sha1>6b74ahbqktsg19qssy87mo7rz9hhs9t</sha1>
+    </revision>
+    <revision>
+      <id>4435</id>
+      <parentid>4434</parentid>
+      <timestamp>2025-10-17T22:41:57Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4435</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="2833" sha1="7ih5xo94wtqba8xjs55t3rjk82vm95p" xml:space="preserve">&lt;PageSchema&gt;
+  &lt;pageforms_Form name="Supply"&gt;
+    &lt;standardInputs inputFreeText="1" freeTextLabel="Free text"/&gt;
+  &lt;/pageforms_Form&gt;
+  &lt;Template name="Supply" format="standard"&gt;
+    &lt;pageforms_TemplateDetails/&gt;
+    &lt;semanticmediawiki_ConnectingProperty name=""/&gt;
+    &lt;Field name=""&gt;
+      &lt;pageforms_FormInput/&gt;
+      &lt;semanticmediawiki_Property name=""&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Name"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Name"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Description"&gt;
+      &lt;Label&gt;Description LABEL&lt;/Label&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;textarea&lt;/InputType&gt;
+        &lt;Description&gt;Description of the description field&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Description"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Price" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;USD (without $)&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Price"&gt;
+        &lt;Type&gt;Quantity&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Suppliers" list="list" display="nonempty"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Supplier&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Supplied By"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Product ID"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+        &lt;Description&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/Description&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Product ID"&gt;
+        &lt;Type&gt;Text&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="Orders" display="hidden"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text with autocomplete&lt;/InputType&gt;
+        &lt;Parameter name="values from category"&gt;Purchase Order&lt;/Parameter&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has Order"&gt;
+        &lt;Type&gt;Page&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+    &lt;Field name="URL"&gt;
+      &lt;pageforms_FormInput&gt;
+        &lt;InputType&gt;text&lt;/InputType&gt;
+      &lt;/pageforms_FormInput&gt;
+      &lt;semanticmediawiki_Property name="Has URL"&gt;
+        &lt;Type&gt;URL&lt;/Type&gt;
+      &lt;/semanticmediawiki_Property&gt;
+    &lt;/Field&gt;
+  &lt;/Template&gt;
+&lt;/PageSchema&gt;
+
+An item that may be part of a standing inventory of lab supplies
+
+See also:
+
+* [[Template:Supply]]
+* [[Form:Supply]]</text>
+      <sha1>7ih5xo94wtqba8xjs55t3rjk82vm95p</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Template:Supply</title>
+    <ns>10</ns>
+    <id>1223</id>
+    <revision>
+      <id>4428</id>
+      <timestamp>2025-10-17T20:58:03Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <comment>Generated from a page schema</comment>
+      <origin>4428</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="809" sha1="88hwzq2c7tia8mc2qik1mctdooh4ogc" xml:space="preserve">&lt;noinclude&gt;
+{{#template_params:|Name (property=Has Name)|Description (label=Description LABEL;property=Has Description)|Price (property=Price;display=nonempty)|Suppliers (list;property=Supplied By;display=nonempty)|Product ID (property=Has Product ID)|Orders (property=Has Order;display=hidden)|URL (property=Has URL)}}
+&lt;/noinclude&gt;&lt;includeonly&gt;{{#set:Has Order=0:{{{Orders|}}}|}}
+{| class="wikitable"
+|-
+! Name
+| [[Has Name::{{{Name|}}}]]
+|-
+! Description LABEL
+| [[Has Description::{{{Description|}}}]]
+{{#if:{{{Price|}}}|
+{{!}}-
+! Price
+{{!}} [[Price::{{{Price|}}}]]
+}}
+{{#if:{{{Suppliers|}}}|
+{{!}}-
+! Suppliers
+{{!}} {{#arraymap:{{{Suppliers|}}}|,|x|[[Supplied By::x]]}}
+
+}}
+|-
+! Product ID
+| [[Has Product ID::{{{Product ID|}}}]]
+|-
+! URL
+| [[Has URL::{{{URL|}}}]]
+|}
+
+[[Category:Supply]]
+&lt;/includeonly&gt;</text>
+      <sha1>88hwzq2c7tia8mc2qik1mctdooh4ogc</sha1>
+    </revision>
+    <revision>
+      <id>4436</id>
+      <parentid>4428</parentid>
+      <timestamp>2025-10-17T22:42:31Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4436</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="774" sha1="74r0pr0u0j83bav7nb67mrelrwnlwf8" xml:space="preserve">&lt;noinclude&gt;
+{{#template_params:|Name (property=Has Name)|Description (label=Description LABEL;property=Has Description)|Price (property=Price;display=nonempty)|Suppliers (list;property=Supplied By;display=nonempty)|Product ID (property=Has Product ID)|Orders (property=Has Order;display=hidden)|URL (property=Has URL)}}
+&lt;/noinclude&gt;&lt;includeonly&gt;
+{| class="wikitable"
+|-
+! Name
+| [[Has Name::{{{Name|}}}]]
+|-
+! Description LABEL
+| [[Has Description::{{{Description|}}}]]
+{{#if:{{{Price|}}}|
+{{!}}-
+! Price
+{{!}} [[Price::{{{Price|}}}]]
+}}
+{{#if:{{{Suppliers|}}}|
+{{!}}-
+! Suppliers
+{{!}} {{#arraymap:{{{Suppliers|}}}|,|x|[[Supplied By::x]]}}
+
+}}
+|-
+! Product ID
+| [[Has Product ID::{{{Product ID|}}}]]
+|-
+! URL
+| [[Has URL::{{{URL|}}}]]
+|}
+
+[[Category:Supply]]
+&lt;/includeonly&gt;</text>
+      <sha1>74r0pr0u0j83bav7nb67mrelrwnlwf8</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Form:Supply</title>
+    <ns>106</ns>
+    <id>1222</id>
+    <revision>
+      <id>4427</id>
+      <timestamp>2025-10-17T20:58:03Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <comment>Generated from a page schema</comment>
+      <origin>4427</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="1395" sha1="pjejvyq163gippa3dsqe6fs4zvs58zt" xml:space="preserve">&lt;noinclude&gt;
+This is the "Supply" form.
+To create a page with this form, enter the page name below;
+if a page with that name already exists, you will be sent to a form to edit that page.
+
+{{#forminput:form=Supply|autocomplete on category=Supply}}
+
+&lt;/noinclude&gt;&lt;includeonly&gt;
+&lt;div id="wikiPreview" style="display: none; padding-bottom: 25px; margin-bottom: 25px; border-bottom: 1px solid #AAAAAA;"&gt;&lt;/div&gt;
+{{{for template|Supply}}}
+{| class="formtable"
+! : 
+| {{{field|}}}
+|-
+! Name: 
+| {{{field|Name|input type=text}}}
+|-
+! Description LABEL: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;Description of the description field&lt;/p&gt;
+| {{{field|Description|input type=textarea}}}
+|-
+! Price: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;USD (without $)&lt;/p&gt;
+| {{{field|Price|input type=text}}}
+|-
+! Suppliers: 
+| {{{field|Suppliers|input type=text with autocomplete|values from category=Supplier}}}
+|-
+! Product ID: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/p&gt;
+| {{{field|Product ID|input type=text}}}
+|-
+! Orders: 
+| {{{field|Orders|input type=text with autocomplete|values from category=Purchase Order}}}
+|-
+! URL: 
+| {{{field|URL|input type=text}}}
+|}
+{{{end template}}}
+
+'''Free text:'''
+
+{{{standard input|free text|rows=10}}}
+&lt;/includeonly&gt;</text>
+      <sha1>pjejvyq163gippa3dsqe6fs4zvs58zt</sha1>
+    </revision>
+    <revision>
+      <id>4431</id>
+      <parentid>4427</parentid>
+      <timestamp>2025-10-17T21:01:57Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4431</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="1372" sha1="kvpxtb6j4tpddh9eb6zln910b1iqoir" xml:space="preserve">&lt;noinclude&gt;
+This is the "Supply" form.
+To create a page with this form, enter the page name below;
+if a page with that name already exists, you will be sent to a form to edit that page.
+
+{{#forminput:form=Supply|autocomplete on category=Supply}}
+
+&lt;/noinclude&gt;&lt;includeonly&gt;
+&lt;div id="wikiPreview" style="display: none; padding-bottom: 25px; margin-bottom: 25px; border-bottom: 1px solid #AAAAAA;"&gt;&lt;/div&gt;
+{{{for template|Supply}}}
+{| class="formtable"
+! Name: 
+| {{{field|Name|input type=text}}}
+|-
+! Description LABEL: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;Description of the description field&lt;/p&gt;
+| {{{field|Description|input type=textarea}}}
+|-
+! Price: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;USD (without $)&lt;/p&gt;
+| {{{field|Price|input type=text}}}
+|-
+! Suppliers: 
+| {{{field|Suppliers|input type=text with autocomplete|values from category=Supplier}}}
+|-
+! Product ID: &lt;br&gt;&lt;p class="pfFieldDescription" style="font-size:0.7em; color:gray;"&gt;The number used to identify the product within a supplier's catalogue, etc.&lt;/p&gt;
+| {{{field|Product ID|input type=text}}}
+|-
+! Orders: 
+| {{{field|Orders|input type=text with autocomplete|values from category=Purchase Order}}}
+|-
+! URL: 
+| {{{field|URL|input type=text}}}
+|}
+{{{end template}}}
+
+'''Free text:'''
+
+{{{standard input|free text|rows=10}}}
+&lt;/includeonly&gt;</text>
+      <sha1>kvpxtb6j4tpddh9eb6zln910b1iqoir</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Buffalo</title>
+    <ns>0</ns>
+    <id>1226</id>
+    <revision>
+      <id>4432</id>
+      <timestamp>2025-10-17T21:05:47Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with "{{Supply |Name=Buffalonio Bites |Description=A nutritious snack heatable in the [[Microwave]] |Price=4.50 |Suppliers=Buffaloni-o's |Product ID=1234-buf-z |URL=http://example.com/bz-crisps }} eifjserlifusrhlgiuh"</comment>
+      <origin>4432</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="210" sha1="ej96l292xm42hacsu0wqxmragvmshw4" xml:space="preserve">{{Supply
+|Name=Buffalonio Bites
+|Description=A nutritious snack heatable in the [[Microwave]]
+|Price=4.50
+|Suppliers=Buffaloni-o's
+|Product ID=1234-buf-z
+|URL=http://example.com/bz-crisps
+}}
+eifjserlifusrhlgiuh</text>
+      <sha1>ej96l292xm42hacsu0wqxmragvmshw4</sha1>
+    </revision>
+    <revision>
+      <id>4437</id>
+      <parentid>4432</parentid>
+      <timestamp>2025-10-17T22:43:26Z</timestamp>
+      <contributor>
+        <username>Jonny</username>
+        <id>1</id>
+      </contributor>
+      <origin>4437</origin>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="221" sha1="gv772gh87fcluljod96w5yinubgeldn" xml:space="preserve">{{Supply
+|Name=Buffalonio Bites
+|Description=A nutritious snack heatable in the [[Microwave]]
+|Price=4.50
+|Suppliers=Buffaloni-o's
+|Product ID=1234-buf-z
+|URL=http://example.com/bz-crisps
+}}
+eifjserlifusrhlgiuh
+
+more text</text>
+      <sha1>gv772gh87fcluljod96w5yinubgeldn</sha1>
+    </revision>
+  </page>
+</mediawiki>

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,86 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from labki_packs_tools.ingest import update_manifest
+from labki_packs_tools.manifest import Manifest
+
+
+@pytest.mark.parametrize("export", ("latest.xml", "revisions.xml"))
+def test_export_update(base_manifest, export_data, export):
+    """
+    Manifests can import pages from a mediawiki export
+
+    - Add any new pages
+    - Update any pages with older timestamps than in the export
+    - Write new pages with a safe name
+    - Touch updated at timestamps
+    - Ignore non-updated pages
+    """
+    old_date = datetime(2020, 1, 1, tzinfo=UTC)
+    future_date = datetime(2030, 1, 1, tzinfo=UTC)
+    export_path = export_data / export
+
+    # manifest with an old file to be updated,
+    # a nonexistant file,
+    # and a file more recent than the export
+    manifest_path = base_manifest(
+        {
+            "last_updated": old_date,
+            "pages": {
+                # should not update
+                "Category:Supply": {
+                    "last_updated": future_date.isoformat(),
+                    "file": "pages/category_supply.wiki",
+                },
+                # should update
+                "Template:Supply": {"last_updated": old_date, "file": "pages/template_supply.wiki"},
+            },
+        }
+    )
+
+    updated = update_manifest(manifest_path, export_path)
+    assert len(updated) == 3
+    assert len(list((manifest_path.parent / "pages").glob("*.wiki"))) == 3
+    manifest = Manifest.from_yaml(manifest_path)
+    assert manifest.last_updated > old_date
+    assert len(manifest.pages) == 4
+    assert manifest.pages["Category:Supply"].last_updated == future_date
+
+
+@pytest.mark.parametrize("export", ("latest.xml", "revisions.xml"))
+def test_export_no_update(base_manifest, export_data, export):
+    """
+    For an export with pages that are older than all the pages in the manifest,
+    we don't change anything
+    """
+    future_date = datetime(2030, 1, 1, tzinfo=UTC)
+    export_path = export_data / export
+
+    # all pages are in the future
+    manifest_path = base_manifest(
+        {
+            "last_updated": future_date.isoformat(),
+            "pages": {
+                "Category:Supply": {
+                    "last_updated": future_date.isoformat(),
+                    "file": "pages/category_supply.wiki",
+                },
+                "Template:Supply": {
+                    "last_updated": future_date.isoformat(),
+                    "file": "pages/template_supply.wiki",
+                },
+                "Form:Supply": {
+                    "last_updated": future_date.isoformat(),
+                    "file": "pages/form_supply.wiki",
+                },
+                "Buffalo": {"last_updated": future_date.isoformat(), "file": "pages/buffalo.wiki"},
+            },
+        }
+    )
+    updated = update_manifest(manifest_path, export_path)
+    assert len(updated) == 0
+    assert len(list((manifest_path.parent / "pages").glob("*.wiki"))) == 0
+    manifest = Manifest.from_yaml(manifest_path)
+    assert manifest.last_updated == future_date
+    assert len(manifest.pages) == 4

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import yaml
+
+from labki_packs_tools.manifest import Manifest
+
+
+def test_manifest_roundtrip_yaml(fixtures_repo: Path):
+    """
+    Test that the Manifest roundtrips a manifest correctly
+    """
+    manifest_path = fixtures_repo / "manifest.yml"
+    with open(manifest_path) as f:
+        data = yaml.safe_load(f)
+
+    model = Manifest.from_yaml(manifest_path)
+    dumped = model.model_dump(exclude_unset=True)
+    assert dumped == data


### PR DESCRIPTION
fix: #27 

Updates a manifest from a mediawiki XML export.

Should be relatively self-explanatory, but just for info:
- Made classes for the manifest and for xml export items, mostly just to have handles on the different file formats rather than working on a bunch of anonymous dicts.
- a handful of `to_*` and `from_*` for each of them,
- wrappers around the process that call them.

Basically it's pretty straightforward, pull the pages from the xml export, match them to any pages already in the manifest, if they don't exist or have been updated since the timestamp in the manifest, then update the timestamp and write the file.

fear not the size of the PR, most of the lines are from the added xml export files used for test data and updating the lockfile